### PR TITLE
Ensure that the description is always required in access-control group

### DIFF
--- a/src/commands/access-control/group/create.ts
+++ b/src/commands/access-control/group/create.ts
@@ -13,7 +13,7 @@ export default class CreateAccessControlGroup extends BaseCommand {
     static flags = {
       description: Flags.string({
         description: 'A description of the group.',
-        required: false,
+        required: true,
       }),
       "itwin-id": Flags.string({
         description: 'The ID of the iTwin where the group is being created.',


### PR DESCRIPTION
https://github.com/iTwin/itwin-cli/issues/16