### PR TITLE
Access control member user and group add examples

### DIFF
--- a/src/commands/access-control/member/group/add.ts
+++ b/src/commands/access-control/member/group/add.ts
@@ -3,13 +3,20 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import { Flags } from "@oclif/core";
+import { Command, Flags } from "@oclif/core";
 
 import BaseCommand from "../../../../extensions/base-command.js";
 import { GroupMember } from "../../../../services/access-control-client/models/group.js";
 
 export default class AddGroupMembers extends BaseCommand {
     static description = 'Add one or more groups as members to an iTwin.';
+
+    static examples: Command.Example[] = [
+      {
+        command: 'itp access-control member group add --itwin-id "ad0ba809-9241-48ad-9eb0-c8038c1a1d51" --groups \'[{"groupId": "group1-id", "roleIds": ["5abbfcef-0eab-472a-b5f5-5c5a43df34b1", "83ee0d80-dea3-495a-b6c0-7bb102ebbcc3"]}, {"groupId": "group2-id", "roleIds": ["5abbfcef-0eab-472a-b5f5-5c5a43df34b1"]}]\',',
+        description: 'Add one or more groups as members to an iTwin.'
+      }
+    ];
   
     static flags = {
       groups: Flags.string({
@@ -37,4 +44,3 @@ export default class AddGroupMembers extends BaseCommand {
       return this.logAndReturnResult(response.members);
     }
   }
-  

--- a/src/commands/access-control/member/user/add.ts
+++ b/src/commands/access-control/member/user/add.ts
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import { Flags } from "@oclif/core";
+import { Command, Flags } from "@oclif/core";
 
 import BaseCommand from "../../../../extensions/base-command.js";
 import { addMember } from "../../../../services/access-control-client/models/members.js";
@@ -11,6 +11,13 @@ import { addMember } from "../../../../services/access-control-client/models/mem
 export default class AddUserMembers extends BaseCommand {
     static description = 'Add one or more user members to an iTwin.';
   
+    static examples: Command.Example[] = [
+     {
+      command: 'itp access-control member user add --itwin-id "ad0ba809-9241-48ad-9eb0-c8038c1a1d51" --members \'[{"email": "user1@example.com", "roleIds": ["5abbfcef-0eab-472a-b5f5-5c5a43df34b1", "83ee0d80-dea3-495a-b6c0-7bb102ebbcc3"]}, {"email": "user2@example.com", "roleIds": ["5abbfcef-0eab-472a-b5f5-5c5a43df34b1"]}]\',',
+      description: 'Add one or more user members to an iTwin.'
+     } 
+    ];
+
     static flags = {
       "itwin-id": Flags.string({
         description: 'The ID of the iTwin to which the users will be added.',
@@ -35,4 +42,3 @@ export default class AddUserMembers extends BaseCommand {
       return this.logAndReturnResult(response);
     }
   }
-  


### PR DESCRIPTION
Fix for the issue https://github.com/iTwin/itwin-cli/issues/17

# Before:
`access-control member group add --help`:
![image](https://github.com/user-attachments/assets/261aa898-6589-4996-b172-04eca8456d3e)

---
`itp access-control member user add --help`:
![image](https://github.com/user-attachments/assets/46fe391a-da52-4422-9209-938c7b0b0565)


# After:
`access-control member group add --help`:
![image](https://github.com/user-attachments/assets/ca8e792c-f7fb-4567-9612-a5f9122cd464)
---
`itp access-control member user add --help`:
![image](https://github.com/user-attachments/assets/f2645cc5-5465-46f4-b86d-bddcfb0e85a0)

