### PR TITLE
Updating `itwin create` type property description and subclass requirement

### DIFF
--- a/docs/itwin/create.md
+++ b/docs/itwin/create.md
@@ -22,7 +22,7 @@ Create a new iTwin with specified properties.
   **Type:** `string` **Required:** Yes
 
 - **`--type`**  
-  Open ended property to define your iTwin's type.
+  Open ended property to define your iTwin's type.  
   **Type:** `string` **Required:** No
 
 - **`--number`**  

--- a/src/commands/itwin/create.ts
+++ b/src/commands/itwin/create.ts
@@ -50,7 +50,7 @@ export default class CreateITwin extends BaseCommand {
       "sub-class": Flags.string({
         description: 'The subClass of your iTwin.',
         options: ["Account", "Portfolio", "Asset", "Program", "Project", "WorkPackage"],
-        required: false,
+        required: true,
       }),
       type: Flags.string({
         description: "An open ended property to better define your iTwin's Type.",


### PR DESCRIPTION
Solution to the issue described here:

https://github.com/iTwin/itwin-cli/issues/21

`type` flag description change to better reflect what this property is 

Also fixed an issue where sub-class was not a requirement