### PR TITLE
Change authentication port from 3000 to 3301

### DIFF
--- a/src/extensions/base-command.ts
+++ b/src/extensions/base-command.ts
@@ -94,7 +94,7 @@ export default abstract class BaseCommand extends Command {
 
     let config : configuration = {
       apiUrl: 'https://api.bentley.com',
-      clientId: 'native-Ekf20w7jmbRcKjEyK9cHbnWU1',
+      clientId: 'native-QJi5VlgxoujsCRwcGHMUtLGMZ',
       clientSecret: undefined,
       issuerUrl: 'https://ims.bentley.com/'
     };

--- a/src/services/authorization-client/authorization-client.ts
+++ b/src/services/authorization-client/authorization-client.ts
@@ -77,7 +77,7 @@ export class AuthorizationClient {
           clientId,
           expiryBuffer: 10 * 60,
           issuerUrl,
-          redirectUri: "http://localhost:3000/signin-callback",
+          redirectUri: "http://localhost:3301/signin-callback",
           scope: "itwin-platform"
         });
 
@@ -112,7 +112,7 @@ export class AuthorizationClient {
           clientId,
           expiryBuffer: 10 * 60,
           issuerUrl,
-          redirectUri: "http://localhost:3000/signin-callback",
+          redirectUri: "http://localhost:3301/signin-callback",
           scope: "itwin-platform"
         });
     


### PR DESCRIPTION
Changed authentication port from 3000 to 3301 as it was pointed out that 3000 is a development port and might be taken when a developer uses the CLI to try to login. 

Because of that needed to update client that is used for logging into iTwinCLI