### PR TITLE
Add `-h` as an additional help flag

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -10,10 +10,6 @@ These options are available across all commands in the CLI.
   Pretty format the JSON command response and supress all logging.
   **Type:** `flag` **Required:** No
 
-- **`-h, --help`**  
-  Show iTwin CLI help.
-  **Type:** `flag` **Required:** No
-
 ## Examples
 
 ```bash

--- a/src/extensions/base-command.ts
+++ b/src/extensions/base-command.ts
@@ -23,12 +23,6 @@ import { configuration } from './configuration.js';
 
 export default abstract class BaseCommand extends Command {
   static baseFlags = {
-    help: Flags.help({ 
-      char: 'h', 
-      description: 'Show iTwin CLI help.',
-      helpGroup: 'GLOBAL',
-      required: false
-    }),
     json: Flags.boolean({
       char: 'j',
       description: 'Pretty format the JSON command response and suppress all logging.',


### PR DESCRIPTION
- Added `-h` as an additional help flag
- Moved global flags to a separate help group.