### PR TITLE
Improved test cleanups and fixed iTwins in context tests not being deleted

### DIFF
--- a/integration-tests/access-control-native/group.test.ts
+++ b/integration-tests/access-control-native/group.test.ts
@@ -29,8 +29,8 @@ const tests = () => describe('group', () => {
     });
 
     after(async () => {
-        const result = await runCommand(`itwin delete --itwin-id ${iTwinId}`);
-        expect(result.stdout).to.contain('deleted');
+        const { result: deleteResult } = await runCommand(`itwin delete --itwin-id ${iTwinId}`);
+        expect(deleteResult).to.have.property('result', 'deleted');
     });
 
     it('Should update group ims-group', async () => {

--- a/integration-tests/access-control-native/member/owner.test.ts
+++ b/integration-tests/access-control-native/member/owner.test.ts
@@ -25,8 +25,8 @@ const tests = () => describe('owner', () => {
     });
 
     after(async () => {
-        const result = await runCommand(`itwin delete --itwin-id ${iTwinId}`);
-        expect(result.stdout).to.contain('deleted');
+        const { result: deleteResult } = await runCommand(`itwin delete --itwin-id ${iTwinId}`);
+        expect(deleteResult).to.have.property('result', 'deleted');
     });
 
     it('Should add an internal member to an iTwin and remove owner member', async () => {

--- a/integration-tests/access-control-native/member/user.test.ts
+++ b/integration-tests/access-control-native/member/user.test.ts
@@ -25,8 +25,8 @@ const tests = () => describe('user', () => {
     });
 
     after(async () => {
-        const result = await runCommand(`itwin delete --itwin-id ${iTwinId}`);
-        expect(result.stdout).to.contain('deleted');
+        const { result: deleteResult } = await runCommand(`itwin delete --itwin-id ${iTwinId}`);
+        expect(deleteResult).to.have.property('result', 'deleted');
     });
 
     it('Should add an internal member to an iTwin and remove user member', async () => {

--- a/integration-tests/access-control/group.test.ts
+++ b/integration-tests/access-control/group.test.ts
@@ -21,8 +21,8 @@ const tests = () => {
     });
 
     after(async () => {
-        const result = await runCommand(`itwin delete --itwin-id ${iTwinId}`);
-        expect(result.stdout).to.contain('deleted');
+        const { result: deleteResult } = await runCommand(`itwin delete --itwin-id ${iTwinId}`);
+        expect(deleteResult).to.have.property('result', 'deleted');
     });
 
     it('Should create and update group info', async () => {

--- a/integration-tests/access-control/member/group.test.ts
+++ b/integration-tests/access-control/member/group.test.ts
@@ -32,8 +32,8 @@ const tests = () => {
     });
 
     after(async () => {
-        const result = await runCommand(`itwin delete --itwin-id ${iTwinId}`);
-        expect(result.stdout).to.contain('deleted');
+        const { result: deleteResult } = await runCommand(`itwin delete --itwin-id ${iTwinId}`);
+        expect(deleteResult).to.have.property('result', 'deleted');
     });
 
     it('Should create, update and list info and delete member group', async () => {

--- a/integration-tests/access-control/member/invitations.test.ts
+++ b/integration-tests/access-control/member/invitations.test.ts
@@ -22,8 +22,8 @@ const tests = () => {
     });
 
     after(async () => {
-        const result = await runCommand(`itwin delete --itwin-id ${iTwinId}`);
-        expect(result.stdout).to.contain('deleted');
+        const { result: deleteResult } = await runCommand(`itwin delete --itwin-id ${iTwinId}`);
+        expect(deleteResult).to.have.property('result', 'deleted');
     });
 
     it('Should get pending invitations', async () => {

--- a/integration-tests/access-control/member/owner.test.ts
+++ b/integration-tests/access-control/member/owner.test.ts
@@ -24,8 +24,8 @@ const tests = () => {
     });
 
     after(async () => {
-        const result = await runCommand(`itwin delete --itwin-id ${iTwinId}`);
-        expect(result.stdout).to.contain('deleted');
+        const { result: deleteResult } = await runCommand(`itwin delete --itwin-id ${iTwinId}`);
+        expect(deleteResult).to.have.property('result', 'deleted');
     });
 
     it('Should invite an external member to an iTwin, accept invitation and remove owner member', async () => {

--- a/integration-tests/access-control/member/user.test.ts
+++ b/integration-tests/access-control/member/user.test.ts
@@ -24,8 +24,8 @@ const tests = () => {
     });
 
     after(async () => {
-        const result = await runCommand(`itwin delete --itwin-id ${iTwinId}`);
-        expect(result.stdout).to.contain('deleted');
+        const { result: deleteResult } = await runCommand(`itwin delete --itwin-id ${iTwinId}`);
+        expect(deleteResult).to.have.property('result', 'deleted');
     });
 
     it('Should invite an external member to an iTwin, accept sent invitation and remove user member', async () => {

--- a/integration-tests/access-control/permissions.test.ts
+++ b/integration-tests/access-control/permissions.test.ts
@@ -20,8 +20,8 @@ const tests = () => {
     });
 
     after(async () => {
-        const result = await runCommand(`itwin delete --itwin-id ${iTwinId}`);
-        expect(result.stdout).to.contain('deleted');
+        const { result: deleteResult} = await runCommand(`itwin delete --itwin-id ${iTwinId}`);
+        expect(deleteResult).to.have.property('result', 'deleted');
     });
 
     it('Should retrieve my permissions', async () => {

--- a/integration-tests/access-control/role.test.ts
+++ b/integration-tests/access-control/role.test.ts
@@ -21,8 +21,8 @@ const tests = () => {
     });
 
     after(async () => {
-        const result = await runCommand(`itwin delete --itwin-id ${iTwinId}`);
-        expect(result.stdout).to.contain('deleted');
+        const { result: deleteResult } = await runCommand(`itwin delete --itwin-id ${iTwinId}`);
+        expect(deleteResult).to.have.property('result', 'deleted');
     });
 
     it('Should create and update role info', async () => {

--- a/integration-tests/api.test.ts
+++ b/integration-tests/api.test.ts
@@ -4,6 +4,7 @@ import { runCommand } from "@oclif/test";
 import { expect } from "chai";
 
 import { User } from "../src/services/user-client/models/user.js";
+import { createITwin } from "./utils/helpers.js";
 import runSuiteIfMainModule from "./utils/run-suite-if-main-module.js";
 
 const tests = () => describe("API Integration Tests", () => {
@@ -21,7 +22,8 @@ const tests = () => describe("API Integration Tests", () => {
     });
 
     after(async () => {
-        await runCommand(`itwin delete -i ${iTwin.id}`);
+        const { result: itwinDeleteResult } = await runCommand(`itwin delete --itwin-id ${iTwin.id}`);
+        expect(itwinDeleteResult).to.have.property('result', 'deleted');
     });
 
     it("should send a GET request and get user me info", async () => {
@@ -69,9 +71,9 @@ const tests = () => describe("API Integration Tests", () => {
     });
 
     it("should send a DELETE request to delete the iTwin", async () => {
-        const apiResponse = await runCommand(`api --method DELETE --path itwins/${iTwin.id} --empty-response`);
-        expect(apiResponse.error).to.be.undefined;
-        const deleteResponse = JSON.parse(apiResponse.stdout);
+        const createdItwin = await createITwin(`cli-itwin-integration-test-${new Date().toISOString()}`, "Thing", "Asset");
+
+        const {result: deleteResponse} = await runCommand(`api --method DELETE --path itwins/${createdItwin.id} --empty-response`);
         expect(deleteResponse).to.have.property("result").that.is.equal("success");
     });
 

--- a/integration-tests/changed-elements/enable-disable-info.test.ts
+++ b/integration-tests/changed-elements/enable-disable-info.test.ts
@@ -12,20 +12,22 @@ import { resultResponse } from '../utils/result-response';
 import runSuiteIfMainModule from '../utils/run-suite-if-main-module';
 
 const tests = () => describe('enable + disable + info', () => {
-  const testIModelName = `IntegrationTestIModel-${new Date().toISOString()}`;
   let testIModelId: string;
   let testITwinId: string;
 
   before(async () => {
-    const testITwin = await createITwin('IntegrationTestITwin', 'Thing', 'Asset');
+    const testITwin = await createITwin(`cli-itwin-integration-test-${new Date().toISOString()}`, 'Thing', 'Asset');
     testITwinId = testITwin.id as string;
-    const testIModel = await createIModel(testIModelName, testITwinId);
+    const testIModel = await createIModel(`cli-imodel-integration-test--${new Date().toISOString()}`, testITwinId);
     testIModelId = testIModel.id;
   });
 
   after(async () => {
-    await runCommand(`imodel delete --imodel-id ${testIModelId}`);
-    await runCommand(`itwin delete --itwin-id ${testITwinId}`);
+    const { result: imodelDeleteResult } = await runCommand(`imodel delete --imodel-id ${testIModelId}`);
+    const { result: itwinDeleteResult } = await runCommand(`itwin delete --itwin-id ${testITwinId}`);
+
+    expect(imodelDeleteResult).to.have.property('result', 'deleted');
+    expect(itwinDeleteResult).to.have.property('result', 'deleted');
   });
 
   it('should have enabled change tracking', async () => {

--- a/integration-tests/context/context.test.ts
+++ b/integration-tests/context/context.test.ts
@@ -31,8 +31,11 @@ const tests = () => describe('Context Integration Tests', () => {
     });
 
     after(async () => {
-      await runCommand(`itwin delete --id ${iTwin.id}`);
-      await runCommand(`itwin delete --id ${anotherITwin.id}`);
+      const { result: deleteResult1 } = await runCommand(`itwin delete -i ${iTwin.id}`);
+      const { result: deleteResult2 } = await runCommand(`itwin delete -i ${anotherITwin.id}`);
+
+      expect(deleteResult1).to.have.property('result', 'deleted');
+      expect(deleteResult2).to.have.property('result', 'deleted');
     });
 
     beforeEach(async () => {

--- a/integration-tests/imodel/create-delete.test.ts
+++ b/integration-tests/imodel/create-delete.test.ts
@@ -6,20 +6,21 @@
 import { runCommand } from '@oclif/test';
 import { expect } from 'chai';
 
-import { createIModel, createITwin, deleteIModel, deleteITwin } from '../utils/helpers';
+import { createIModel, createITwin, deleteIModel } from '../utils/helpers';
 import runSuiteIfMainModule from '../utils/run-suite-if-main-module';
 
 const tests = () => describe('create + delete', () => {
-  const testIModelName = 'IntegrationTestIModel';
+  const testIModelName = `cli-imodel-integration-test-${new Date().toISOString()}`;
   let testITwinId: string;
 
   before(async () => {
-    const testITwin = await createITwin('IntegrationTestITwin', 'Thing', 'Asset');
+    const testITwin = await createITwin(`cli-itwin-integration-test-${new Date().toISOString()}`, 'Thing', 'Asset');
     testITwinId = testITwin.id as string;
   });
 
-  after(async () => {
-    await deleteITwin(testITwinId);    
+  after(async () => { 
+    const { result: deleteResult } = await runCommand(`itwin delete --itwin-id ${testITwinId}`);
+    expect(deleteResult).to.have.property('result', 'deleted');
   });
 
   it('should create a new iModel', async () => {

--- a/integration-tests/imodel/info.test.ts
+++ b/integration-tests/imodel/info.test.ts
@@ -6,24 +6,27 @@
 import { runCommand } from '@oclif/test';
 import { expect } from 'chai';
 
-import { createIModel, createITwin, deleteIModel, deleteITwin } from '../utils/helpers';
+import { createIModel, createITwin } from '../utils/helpers';
 import runSuiteIfMainModule from '../utils/run-suite-if-main-module';
 
 const tests = () => describe('info', () => {
-  const testIModelName = 'IntegrationTestIModel';
+  const testIModelName = `cli-imodel-integration-test-${new Date().toISOString()}`;
   let testIModelId: string;
   let testITwinId: string;
 
   before(async () => {
-    const testITwin = await createITwin('IntegrationTestITwin', 'Thing', 'Asset');
+    const testITwin = await createITwin(`cli-itwin-integration-test-${new Date().toISOString()}`, 'Thing', 'Asset');
     testITwinId = testITwin.id as string;
     const testIModel = await createIModel(testIModelName, testITwinId);
     testIModelId = testIModel.id;
   });
 
   after(async () => {
-    await deleteIModel(testIModelId);
-    await deleteITwin(testITwinId);
+    const { result: imodelDeleteResult } = await runCommand(`imodel delete --imodel-id ${testIModelId}`);
+    const { result: itwinDeleteResult } = await runCommand(`itwin delete --itwin-id ${testITwinId}`);
+
+    expect(imodelDeleteResult).to.have.property('result', 'deleted');
+    expect(itwinDeleteResult).to.have.property('result', 'deleted');
   });
 
   it('should get the iModel info', async () => {

--- a/integration-tests/imodel/list.test.ts
+++ b/integration-tests/imodel/list.test.ts
@@ -6,24 +6,27 @@
 import { runCommand } from '@oclif/test';
 import { expect } from 'chai';
 
-import { createIModel, createITwin, deleteIModel, deleteITwin } from '../utils/helpers';
+import { createIModel, createITwin } from '../utils/helpers';
 import runSuiteIfMainModule from '../utils/run-suite-if-main-module';
 
 const tests = () => describe('list', () => {
-  const testIModelName = 'IntegrationTestIModel';
+  const testIModelName = `cli-imodel-integration-test-${new Date().toISOString()}`;
   let testIModelId: string;
   let testITwinId: string;
 
   before(async () => {
-    const testITwin = await createITwin('IntegrationTestITwin', 'Thing', 'Asset');
+    const testITwin = await createITwin(`cli-itwin-integration-test-${new Date().toISOString()}`, 'Thing', 'Asset');
     testITwinId = testITwin.id as string;
     const testIModel = await createIModel(testIModelName, testITwinId);
     testIModelId = testIModel.id;
   });
 
   after(async () => {
-    await deleteIModel(testIModelId);
-    await deleteITwin(testITwinId);
+    const { result: imodelDeleteResult } = await runCommand(`imodel delete --imodel-id ${testIModelId}`);
+    const { result: itwinDeleteResult } = await runCommand(`itwin delete --itwin-id ${testITwinId}`);
+
+    expect(imodelDeleteResult).to.have.property('result', 'deleted');
+    expect(itwinDeleteResult).to.have.property('result', 'deleted');
   });
 
   it('should list all iModels for the specified iTwin', async () => {

--- a/integration-tests/imodel/populate.test.ts
+++ b/integration-tests/imodel/populate.test.ts
@@ -17,9 +17,9 @@ const tests = () => describe('populate', () => {
   let testITwinId: string;
 
   before(async () => {
-    const testITwin = await createITwin('IntegrationTestITwin', 'Thing', 'Asset');
+    const testITwin = await createITwin(`cli-itwin-integration-test-${new Date().toISOString()}`, 'Thing', 'Asset');
     testITwinId = testITwin.id!;
-    const testIModel = await createIModel('IntegrationTestIModel', testITwinId);
+    const testIModel = await createIModel(`cli-imodel-integration-test-${new Date().toISOString()}`, testITwinId);
     testIModelId = testIModel.id!;
     const rootFolderId = await getRootFolderId(testITwinId);
     const testFile = await createFile(rootFolderId, testFileName, testFilePath);
@@ -27,13 +27,13 @@ const tests = () => describe('populate', () => {
   });
 
   after(async () => {
-    const fileDeleteResult = await runCommand(`storage file delete --file-id ${testFileId}`);
-    const iModelDeleteResult = await runCommand(`imodel delete --imodel-id ${testIModelId}`);
-    const iTwinDeleteResult = await runCommand(`itwin delete --itwin-id ${testITwinId}`);
+    const { result: fileDeleteResult } = await runCommand(`storage file delete --file-id ${testFileId}`);
+    const { result: iModelDeleteResult } = await runCommand(`imodel delete --imodel-id ${testIModelId}`);
+    const { result: iTwinDeleteResult } = await runCommand(`itwin delete --itwin-id ${testITwinId}`);
 
-    expect(fileDeleteResult.result).to.have.property('result', 'deleted');
-    expect(iModelDeleteResult.result).to.have.property('result', 'deleted');
-    expect(iTwinDeleteResult.result).to.have.property('result', 'deleted');
+    expect(fileDeleteResult).to.have.property('result', 'deleted');
+    expect(iModelDeleteResult).to.have.property('result', 'deleted');
+    expect(iTwinDeleteResult).to.have.property('result', 'deleted');
   });
 
   it('should populate the iModel with the uploaded file', async () => {

--- a/integration-tests/imodel/update.test.ts
+++ b/integration-tests/imodel/update.test.ts
@@ -6,7 +6,7 @@
 import { runCommand } from '@oclif/test';
 import { expect } from 'chai';
 
-import { createIModel, createITwin, deleteIModel, deleteITwin } from '../utils/helpers';
+import { createIModel, createITwin } from '../utils/helpers';
 import runSuiteIfMainModule from '../utils/run-suite-if-main-module';
 
 const tests = () => describe('update', () => {
@@ -14,15 +14,18 @@ const tests = () => describe('update', () => {
   let testITwinId: string;
 
   before(async () => {
-    const testITwin = await createITwin('IntegrationTestITwin', 'Thing', 'Asset');
+    const testITwin = await createITwin(`cli-itwin-integration-test-${new Date().toISOString()}`, 'Thing', 'Asset');
     testITwinId = testITwin.id as string;
-    const testIModel = await createIModel('IntegrationTestIModel', testITwinId);
+    const testIModel = await createIModel(`cli-imodel-integration-test-${new Date().toISOString()}`, testITwinId);
     testIModelId = testIModel.id;
   });
 
   after(async () => {
-    await deleteIModel(testIModelId);
-    await deleteITwin(testITwinId);
+    const { result: imodelDeleteResult } = await runCommand(`imodel delete --imodel-id ${testIModelId}`);
+    const { result: itwinDeleteResult } = await runCommand(`itwin delete --itwin-id ${testITwinId}`);
+
+    expect(imodelDeleteResult).to.have.property('result', 'deleted');
+    expect(itwinDeleteResult).to.have.property('result', 'deleted');
   });
 
   it('should update the iModel', async () => {

--- a/integration-tests/itwin/create.test.ts
+++ b/integration-tests/itwin/create.test.ts
@@ -26,9 +26,13 @@ const tests = () => describe('create', () => {
   const testNumber = Math.random().toString(36).slice(2)
 
   after(async () => {
-    await runCommand(`itwin delete --itwin-id ${testITwinChildId}`);
-    await runCommand(`itwin delete --itwin-id ${testITwinId}`);
-    await runCommand(`itwin delete --itwin-id ${testITwinId2}`);
+    const { result: deleteResult1 } = await runCommand(`itwin delete --itwin-id ${testITwinChildId}`);
+    const { result: deleteResult2 } = await runCommand(`itwin delete --itwin-id ${testITwinId}`);
+    const { result: deleteResult3 } = await runCommand(`itwin delete --itwin-id ${testITwinId2}`);
+
+    expect(deleteResult1).to.have.property('result', 'deleted');
+    expect(deleteResult2).to.have.property('result', 'deleted');
+    expect(deleteResult3).to.have.property('result', 'deleted');
   })
 
   it('should create a new iTwin', async () => {

--- a/integration-tests/itwin/delete.test.ts
+++ b/integration-tests/itwin/delete.test.ts
@@ -14,12 +14,11 @@ const tests = () => describe('delete', () => {
   let testITwin: ITwin;
 
   before(async () => {
-    testITwin = await createITwin('IntegrationTestITwin', 'Thing', 'Asset');
+    testITwin = await createITwin(`cli-itwin-integration-test-${new Date().toISOString()}`, 'Thing', 'Asset');
   });
 
   it('should delete the iTwin', async () => {
-    const result = await runCommand(`itwin delete --itwin-id ${testITwin.id}`);
-    const deleteResult = JSON.parse(result.stdout);
+    const { result: deleteResult } = await runCommand(`itwin delete --itwin-id ${testITwin.id}`);
     expect(deleteResult).to.have.property('result', 'deleted');
 
     const itwinChildResult = await runCommand(`itwin info --itwin-id ${testITwin.id}`);

--- a/integration-tests/itwin/info.test.ts
+++ b/integration-tests/itwin/info.test.ts
@@ -6,11 +6,11 @@
 import { runCommand } from '@oclif/test';
 import { expect } from 'chai';
 
-import { createITwin, deleteITwin } from '../utils/helpers';
+import { createITwin } from '../utils/helpers';
 import runSuiteIfMainModule from '../utils/run-suite-if-main-module';
 
 const tests = () => describe('info', () => {
-  const name = 'IntegrationTestITwin';
+  const name = `cli-itwin-integration-test-${new Date().toISOString()}`;
   const classType = 'Thing';
   const subClass = 'Asset';
   let testITwinId: string;
@@ -21,13 +21,14 @@ const tests = () => describe('info', () => {
   });
 
   after(async () => {
-    await deleteITwin(testITwinId);
+    const deleteResult = await runCommand(`itwin delete --itwin-id ${testITwinId}`);
+    expect(deleteResult.result).to.have.property('result', 'deleted');
   });
 
   it('should get the iTwin info', async () => {
     const { stdout } = await runCommand(`itwin info --itwin-id ${testITwinId}`);
     const iTwinInfo = JSON.parse(stdout);
-
+    
     expect(iTwinInfo).to.have.property('id', testITwinId);
     expect(iTwinInfo).to.have.property('displayName', name);
     expect(iTwinInfo).to.have.property('class', classType);

--- a/integration-tests/itwin/list.test.ts
+++ b/integration-tests/itwin/list.test.ts
@@ -15,22 +15,22 @@ const tests = () => describe('list', () => {
   let testITwin2: ITwin;
 
   before(async () => {
-    const result1 = await runCommand<ITwin>(`itwin create --name IntegrationTestITwin --class Thing --sub-class Asset --type Type1 --number ${Math.random().toString(36).slice(2)}`); 
+    const result1 = await runCommand<ITwin>(`itwin create --name IntegrationTestITwin_${new Date().toISOString()} --class Thing --sub-class Asset --type Type1 --number ${Math.random().toString(36).slice(2)}`); 
     testITwin1 = result1.result as ITwin;
-    const result2 = await runCommand<ITwin>(`itwin create --name IntegrationTestITwinChild --class Thing --sub-class Asset --parent-id ${testITwin1.id} --status Inactive`);
+    const result2 = await runCommand<ITwin>(`itwin create --name IntegrationTestITwinChild_${new Date().toISOString()} --class Thing --sub-class Asset --parent-id ${testITwin1.id} --status Inactive`);
     testITwin1Child = result2.result as ITwin;
-    const result3 = await runCommand<ITwin>(`itwin create --name OtherIntegrationTestITwin --class Endeavor --sub-class Project --data-center-location "UK South" --iana-time-zone America/Los_Angeles --geographic-location "San Francisco, CA"`);
+    const result3 = await runCommand<ITwin>(`itwin create --name OtherIntegrationTestITwin_${new Date().toISOString()} --class Endeavor --sub-class Project --data-center-location "UK South" --iana-time-zone America/Los_Angeles --geographic-location "San Francisco, CA"`);
     testITwin2 = result3.result as ITwin;
   });
 
   after(async () => {
-    const deleteResult1 = await runCommand(`itwin delete --itwin-id ${testITwin1Child.id}`);
-    const deleteResult2 = await runCommand(`itwin delete --itwin-id ${testITwin1.id}`);
-    const deleteResult3 = await runCommand(`itwin delete --itwin-id ${testITwin2.id}`);
+    const { result: deleteResult1 } = await runCommand(`itwin delete --itwin-id ${testITwin1Child.id}`);
+    const { result: deleteResult2 } = await runCommand(`itwin delete --itwin-id ${testITwin1.id}`);
+    const { result: deleteResult3 } = await runCommand(`itwin delete --itwin-id ${testITwin2.id}`);
 
-    expect(deleteResult1.result).to.have.property('result', 'deleted');
-    expect(deleteResult2.result).to.have.property('result', 'deleted');
-    expect(deleteResult3.result).to.have.property('result', 'deleted');
+    expect(deleteResult1).to.have.property('result', 'deleted');
+    expect(deleteResult2).to.have.property('result', 'deleted');
+    expect(deleteResult3).to.have.property('result', 'deleted');
   })
 
   it('should fail when provided bad subClass', async () => {

--- a/integration-tests/itwin/repository.test.ts
+++ b/integration-tests/itwin/repository.test.ts
@@ -6,7 +6,7 @@
 import { runCommand } from '@oclif/test';
 import { expect } from 'chai';
 
-import { createITwin, deleteITwin } from '../utils/helpers';
+import { createITwin } from '../utils/helpers';
 import runSuiteIfMainModule from '../utils/run-suite-if-main-module';
 
 const tests = () => describe('repository', () => {
@@ -17,12 +17,13 @@ const tests = () => describe('repository', () => {
   let iModelUri: string;
 
   before(async () => {
-    const testITwin = await createITwin('IntegrationTestITwin', 'Thing', 'Asset');
+    const testITwin = await createITwin(`cli-itwin-integration-test-${new Date().toISOString()}`, 'Thing', 'Asset');
     testITwinId = testITwin.id as string;
   });
 
   after(async () => {
-    await deleteITwin(testITwinId);
+    const { result: deleteResult } = await runCommand(`itwin delete --itwin-id ${testITwinId}`);
+    expect(deleteResult).to.have.property('result', 'deleted');
   });
 
   it('should create a new iTwin repository', async () => {

--- a/integration-tests/itwin/update.test.ts
+++ b/integration-tests/itwin/update.test.ts
@@ -7,22 +7,22 @@ import { ITwin } from "@itwin/itwins-client";
 import { runCommand } from '@oclif/test';
 import { expect } from 'chai';
 
-import { createITwin, deleteITwin } from '../utils/helpers';
+import { createITwin } from '../utils/helpers';
 import runSuiteIfMainModule from "../utils/run-suite-if-main-module";
 
 const tests = () => describe('update', () => {
-  const name = 'IntegrationTestITwin';
   const classType = 'Thing';
   const subClass = 'Asset';
   let testITwinId: string;
 
   before(async () => {
-    const testITwin = await createITwin(name, classType, subClass);
+    const testITwin = await createITwin(`cli-itwin-integration-test-${new Date().toISOString()}`, classType, subClass);
     testITwinId = testITwin.id as string;
   });
 
   after(async () => {
-    await deleteITwin(testITwinId);
+    const { result: deleteResult } = await runCommand(`itwin delete --itwin-id ${testITwinId}`);
+    expect(deleteResult).to.have.property('result', 'deleted');
   });
 
   it('should update the iTwin', async () => {

--- a/integration-tests/storage/file/create-upload-complete-delete.test.ts
+++ b/integration-tests/storage/file/create-upload-complete-delete.test.ts
@@ -8,9 +8,7 @@ import { expect } from 'chai';
 
 import { 
   createFolder, 
-  createITwin, 
-  deleteFolder, 
-  deleteITwin, 
+  createITwin,  
   getRootFolderId 
 } from '../../utils/helpers';
 import runSuiteIfMainModule from '../../utils/run-suite-if-main-module';
@@ -25,7 +23,7 @@ const tests = () => describe('create + upload + complete + delete', () => {
   const description = 'Test description';
 
   before(async () => {
-    const testITwin = await createITwin('IntegrationTestITwin', 'Thing', 'Asset');
+    const testITwin = await createITwin(`cli-itwin-integration-test-${new Date().toISOString()}`, 'Thing', 'Asset');
     testITwinId = testITwin.id as string;
     rootFolderId = await getRootFolderId(testITwinId);
     const testFolder = await createFolder(rootFolderId, 'IntegrationTestFolder', 'Test description');
@@ -33,8 +31,11 @@ const tests = () => describe('create + upload + complete + delete', () => {
   });
 
   after(async () => {
-    await deleteFolder(testFolderId);
-    await deleteITwin(testITwinId);
+    const { result: folderDeleteResult } = await runCommand(`storage folder delete --folder-id ${testFolderId}`);
+    const { result: itwinDeleteResult } = await runCommand(`itwin delete --itwin-id ${testITwinId}`);
+
+    expect(folderDeleteResult).to.have.property('result', 'deleted');
+    expect(itwinDeleteResult).to.have.property('result', 'deleted');
   });
 
   it('should create a new file meta data', async () => {

--- a/integration-tests/storage/file/info.test.ts
+++ b/integration-tests/storage/file/info.test.ts
@@ -10,9 +10,6 @@ import {
   createFile,
   createIModel,
   createITwin, 
-  deleteFile, 
-  deleteIModel, 
-  deleteITwin, 
   getRootFolderId 
 } from '../../utils/helpers';
 import runSuiteIfMainModule from '../../utils/run-suite-if-main-module';
@@ -25,9 +22,9 @@ const tests = () => describe('info', () => {
   let testITwinId: string;
 
   before(async () => {
-    const testITwin = await createITwin('IntegrationTestITwin', 'Thing', 'Asset');
+    const testITwin = await createITwin(`cli-itwin-integration-test-${new Date().toISOString()}`, 'Thing', 'Asset');
     testITwinId = testITwin.id as string;
-    const testIModel = await createIModel('IntegrationTestIModel', testITwinId);
+    const testIModel = await createIModel(`cli-imodel-integration-test-${new Date().toISOString()}`, testITwinId);
     testIModelId = testIModel.id;
     const rootFolderId = await getRootFolderId(testITwinId);
     const testFile = await createFile(rootFolderId, testFileName, testFilePath);
@@ -35,9 +32,13 @@ const tests = () => describe('info', () => {
   });
 
   after(async () => {
-    await deleteFile(testFileId);
-    await deleteIModel(testIModelId);
-    await deleteITwin(testITwinId);
+    const { result: fileDeleteResult } = await runCommand(`storage file delete --file-id ${testFileId}`);
+    const { result: imodelDeleteResult } = await runCommand(`imodel delete --imodel-id ${testIModelId}`);
+    const { result: itwinDeleteResult } = await runCommand(`itwin delete --itwin-id ${testITwinId}`);
+
+    expect(fileDeleteResult).to.have.property('result', 'deleted');
+    expect(imodelDeleteResult).to.have.property('result', 'deleted');
+    expect(itwinDeleteResult).to.have.property('result', 'deleted');
   });
 
   it('should get the info of the file', async () => {

--- a/integration-tests/storage/file/list.test.ts
+++ b/integration-tests/storage/file/list.test.ts
@@ -10,9 +10,6 @@ import {
   createFile,
   createFolder,
   createITwin, 
-  deleteFile, 
-  deleteFolder, 
-  deleteITwin, 
   getRootFolderId 
 } from '../../utils/helpers';
 import runSuiteIfMainModule from '../../utils/run-suite-if-main-module';
@@ -26,7 +23,7 @@ const tests = () => describe('list', () => {
   let testFileId: string;
 
   before(async () => {
-    const testITwin = await createITwin('IntegrationTestITwin', 'Thing', 'Asset');
+    const testITwin = await createITwin(`cli-itwin-integration-test-${new Date().toISOString()}`, 'Thing', 'Asset');
     testITwinId = testITwin.id as string;
     rootFolderId = await getRootFolderId(testITwinId);
     const testFolder = await createFolder(rootFolderId, "IntegrationTestFolder", "Test description")
@@ -36,9 +33,13 @@ const tests = () => describe('list', () => {
   });
 
   after(async () => {
-    await deleteFolder(testFolderId);
-    await deleteFile(testFileId);
-    await deleteITwin(testITwinId);
+    const { result: fileDeleteResult } = await runCommand(`storage file delete --file-id ${testFileId}`);
+    const { result: folderDeleteResult } = await runCommand(`storage folder delete --folder-id ${testFolderId}`);
+    const { result: itwinDeleteResult } = await runCommand(`itwin delete --itwin-id ${testITwinId}`);
+
+    expect(fileDeleteResult).to.have.property('result', 'deleted');
+    expect(folderDeleteResult).to.have.property('result', 'deleted');
+    expect(itwinDeleteResult).to.have.property('result', 'deleted');
   });
 
   it('should list the files in the specified folder', async () => {

--- a/integration-tests/storage/file/update.test.ts
+++ b/integration-tests/storage/file/update.test.ts
@@ -10,9 +10,6 @@ import {
   createFile,
   createIModel,
   createITwin, 
-  deleteFile, 
-  deleteIModel, 
-  deleteITwin, 
   getRootFolderId 
 } from '../../utils/helpers';
 
@@ -24,9 +21,9 @@ const tests = () => describe('update', () => {
   let testITwinId: string;
 
   before(async () => {
-    const testITwin = await createITwin('IntegrationTestITwin', 'Thing', 'Asset');
+    const testITwin = await createITwin(`cli-itwin-integration-test-${new Date().toISOString()}`, 'Thing', 'Asset');
     testITwinId = testITwin.id as string;
-    const testIModel = await createIModel('IntegrationTestIModel', testITwinId);
+    const testIModel = await createIModel(`cli-imodel-integration-test-${new Date().toISOString()}`, testITwinId);
     testIModelId = testIModel.id;
     const rootFolderId = await getRootFolderId(testITwinId);
     const testFile = await createFile(rootFolderId, testFileName, testFilePath);
@@ -34,9 +31,13 @@ const tests = () => describe('update', () => {
   });
 
   after(async () => {
-    await deleteFile(testFileId);
-    await deleteIModel(testIModelId);
-    await deleteITwin(testITwinId);
+    const { result: fileDeleteResult } = await runCommand(`storage file delete --file-id ${testFileId}`);
+    const { result: imodelDeleteResult } = await runCommand(`imodel delete --imodel-id ${testIModelId}`);
+    const { result: itwinDeleteResult } = await runCommand(`itwin delete --itwin-id ${testITwinId}`);
+
+    expect(fileDeleteResult).to.have.property('result', 'deleted');
+    expect(imodelDeleteResult).to.have.property('result', 'deleted');
+    expect(itwinDeleteResult).to.have.property('result', 'deleted');
   });
 
   it('should update the file\'s meta data', async () => {

--- a/integration-tests/storage/folder/create-delete.test.ts
+++ b/integration-tests/storage/folder/create-delete.test.ts
@@ -10,25 +10,24 @@ import {
   createFolder, 
   createITwin, 
   deleteFolder, 
-  deleteITwin, 
   getRootFolderId, 
 } from '../../utils/helpers';
 import runSuiteIfMainModule from '../../utils/run-suite-if-main-module';
 
 const tests = () => describe('create + delete', () => {
-  const name = 'IntegrationTestITwin';
   const classType = 'Thing';
   const subClass = 'Asset';
   let testITwinId: string;
   let testFolderId: string;
 
   before(async () => {
-    const testITwin = await createITwin(name, classType, subClass);
+    const testITwin = await createITwin(`cli-itwin-integration-test-${new Date().toISOString()}`, classType, subClass);
     testITwinId = testITwin.id as string;
   });
 
   after(async () => {
-    await deleteITwin(testITwinId);
+    const { result: itwinDeleteResult } = await runCommand(`itwin delete --itwin-id ${testITwinId}`);
+    expect(itwinDeleteResult).to.have.property('result', 'deleted');
   });
 
   it('should create a new folder', async () => {

--- a/integration-tests/storage/folder/info.test.ts
+++ b/integration-tests/storage/folder/info.test.ts
@@ -9,8 +9,6 @@ import { expect } from 'chai';
 import { 
   createFolder, 
   createITwin, 
-  deleteFolder, 
-  deleteITwin, 
   getRootFolderId 
 } from '../../utils/helpers';
 import runSuiteIfMainModule from '../../utils/run-suite-if-main-module';
@@ -21,7 +19,7 @@ const tests = () => describe('info', () => {
   let testITwinId: string;
 
   before(async () => {
-    const testITwin = await createITwin('IntegrationTestITwin', 'Thing', 'Asset');
+    const testITwin = await createITwin(`cli-itwin-integration-test-${new Date().toISOString()}`, 'Thing', 'Asset');
     testITwinId = testITwin.id as string;
     rootFolderId = await getRootFolderId(testITwinId);
     const testFolder = await createFolder(rootFolderId, 'IntegrationTestFolder', 'Test description');
@@ -29,8 +27,11 @@ const tests = () => describe('info', () => {
   });
 
   after(async () => {
-    await deleteFolder(testFolderId);
-    await deleteITwin(testITwinId);
+    const { result: folderDeleteResult } = await runCommand(`storage folder delete --folder-id ${testFolderId}`);
+    const { result: itwinDeleteResult } = await runCommand(`itwin delete --itwin-id ${testITwinId}`);
+
+    expect(folderDeleteResult).to.have.property('result', 'deleted');
+    expect(itwinDeleteResult).to.have.property('result', 'deleted');
   });
 
   it('should get the info of the folder', async () => {

--- a/integration-tests/storage/folder/list.test.ts
+++ b/integration-tests/storage/folder/list.test.ts
@@ -10,9 +10,6 @@ import {
   createFile,
   createFolder, 
   createITwin, 
-  deleteFile, 
-  deleteFolder, 
-  deleteITwin, 
   getRootFolderId 
 } from '../../utils/helpers';
 import runSuiteIfMainModule from '../../utils/run-suite-if-main-module';
@@ -26,7 +23,7 @@ const tests = () => describe('list', () => {
   let testFileId: string;
 
   before(async () => {
-    const testITwin = await createITwin('IntegrationTestITwin', 'Thing', 'Asset');
+    const testITwin = await createITwin(`cli-itwin-integration-test-${new Date().toISOString()}`, 'Thing', 'Asset');
     testITwinId = testITwin.id as string;
     rootFolderId = await getRootFolderId(testITwinId);
     const testFolder = await createFolder(rootFolderId, 'IntegrationTestFolder', 'Test description');
@@ -36,9 +33,13 @@ const tests = () => describe('list', () => {
   });
 
   after(async () => {
-    await deleteFolder(testFolderId);
-    await deleteFile(testFileId);
-    await deleteITwin(testITwinId);
+    const { result: fileDeleteResult } = await runCommand(`storage file delete --file-id ${testFileId}`);
+    const { result: folderDeleteResult } = await runCommand(`storage folder delete --folder-id ${testFolderId}`);
+    const { result: itwinDeleteResult } = await runCommand(`itwin delete --itwin-id ${testITwinId}`);
+
+    expect(fileDeleteResult).to.have.property('result', 'deleted');
+    expect(folderDeleteResult).to.have.property('result', 'deleted');
+    expect(itwinDeleteResult).to.have.property('result', 'deleted');
   });
 
   it('should get the list of folders in the specified folder', async () => {

--- a/integration-tests/storage/folder/update.test.ts
+++ b/integration-tests/storage/folder/update.test.ts
@@ -9,8 +9,6 @@ import { expect } from 'chai';
 import { 
   createFolder, 
   createITwin, 
-  deleteFolder, 
-  deleteITwin, 
   getRootFolderId 
 } from '../../utils/helpers';
 import runSuiteIfMainModule from '../../utils/run-suite-if-main-module';
@@ -21,7 +19,7 @@ const tests = () => describe('update', () => {
   let testITwinId: string;
 
   before(async () => {
-    const testITwin = await createITwin('IntegrationTestITwin', 'Thing', 'Asset');
+    const testITwin = await createITwin(`cli-itwin-integration-test-${new Date().toISOString()}`, 'Thing', 'Asset');
     testITwinId = testITwin.id as string;
     rootFolderId = await getRootFolderId(testITwinId);
     const testFolder = await createFolder(rootFolderId, 'IntegrationTestFolder', 'Test description');
@@ -29,8 +27,11 @@ const tests = () => describe('update', () => {
   });
 
   after(async () => {
-    await deleteFolder(testFolderId);
-    await deleteITwin(testITwinId);
+    const { result: folderDeleteResult } = await runCommand(`storage folder delete --folder-id ${testFolderId}`);
+    const { result: itwinDeleteResult } = await runCommand(`itwin delete --itwin-id ${testITwinId}`);
+
+    expect(folderDeleteResult).to.have.property('result', 'deleted');
+    expect(itwinDeleteResult).to.have.property('result', 'deleted');
   });
 
   it('should update the folder', async () => {

--- a/integration-tests/storage/root-folder.test.ts
+++ b/integration-tests/storage/root-folder.test.ts
@@ -10,25 +10,25 @@ import { expect } from 'chai';
 import { fileTyped } from '../../src/services/storage-client/models/file-typed.js';
 import { folderTyped } from "../../src/services/storage-client/models/folder-typed.js";
 import { itemsWithFolderLink } from "../../src/services/storage-client/models/items-with-folder-link.js";
-import { createFile, createFolder, createITwin, deleteITwin, getRootFolderId } from '../utils/helpers.js';
+import { createFile, createFolder, createITwin, getRootFolderId } from '../utils/helpers.js';
 import runSuiteIfMainModule from '../utils/run-suite-if-main-module.js';
 
 const tests = () => describe('root-folder', () => {
-  const name = 'IntegrationTestITwin';
   let testITwin: ITwin;
   let rootFolderId: string;
   let testFolder: folderTyped;
   let testFile: fileTyped;
 
   before(async () => {
-    testITwin = await createITwin(name, 'Thing', 'Asset');
+    testITwin = await createITwin(`cli-itwin-integration-test-${new Date().toISOString()}`, 'Thing', 'Asset');
     rootFolderId = await getRootFolderId(testITwin.id as string) as string;
     testFolder = await createFolder(rootFolderId, 'IntegrationTestFolder', 'Test description');
     testFile = await createFile(rootFolderId, 'test.zip', 'integration-tests/test.zip');
   });
 
   after(async () => {
-    await deleteITwin(testITwin.id as string);
+    const { result: itwinDeleteResult } = await runCommand(`itwin delete --itwin-id ${testITwin.id}`);
+    expect(itwinDeleteResult).to.have.property('result', 'deleted');
   });
 
   it('should get the root folder with all items', async () => {


### PR DESCRIPTION
- Added expect() statements to test cleanups in order to catch any cleanup errors. 
- Fixed cleanup not working in context tests.