### PR TITLE
Updated itp context set command to not use existing context.

### DIFF
--- a/integration-tests/context/context.test.ts
+++ b/integration-tests/context/context.test.ts
@@ -54,9 +54,13 @@ const tests = () => describe('Context Integration Tests', () => {
     });
 
     it('should set the context', async () => {
-        const output = await runCommand(`context set --itwin-id ${iTwin.id} --imodel-id ${iModel.id}`);
-        expect(output.error).to.be.undefined;
-        expect(output.result).to.deep.equal({ iModelId: iModel.id, iTwinId: iTwin.id });
+        const output1 = await runCommand(`context set --itwin-id ${iTwin.id} --imodel-id ${iModel.id}`);
+        expect(output1.error).to.be.undefined;
+        expect(output1.result).to.deep.equal({ iModelId: iModel.id, iTwinId: iTwin.id });
+
+        const output2 = await runCommand(`context set --itwin-id ${anotherITwin.id}`);
+        expect(output2.error).to.be.undefined;
+        expect(output2.result).to.deep.equal({ iModelId: undefined, iTwinId: anotherITwin.id });
     });
 
     it('should fail to set context with invalid iTwin ID', async () => {
@@ -75,7 +79,7 @@ const tests = () => describe('Context Integration Tests', () => {
     it('should fail to set context without iTwin or iModel ID', async () => {
         const output = await runCommand('context set');
         expect(output.error).to.not.be.undefined;
-        expect(output.error?.message).to.contain('Either --itwin-id or --imodel-id must be provided.');
+        expect(output.error?.message).to.contain('At least one of the following must be provided: --imodel-id, --itwin-id');
     });
 
     it('should display the current context', async () => {

--- a/src/commands/context/set.ts
+++ b/src/commands/context/set.ts
@@ -29,6 +29,7 @@ export default class SetContext extends BaseCommand {
 
     static flags = {
         "imodel-id": Flags.string({
+            atLeastOne: ['imodel-id', 'itwin-id'],
             char: 'm',
             description: "The ID of the iModel to create a context for.",
             helpValue: '<string>',
@@ -43,10 +44,10 @@ export default class SetContext extends BaseCommand {
     };
 
     async run() {
-        const { flags } = await this.parse(SetContext);
+        const { flags } = await this.parseWithoutContext(SetContext);
         const iModelId = flags["imodel-id"];
         let iTwinId = flags["itwin-id"];
-        
+
         // If iModelId is provided, check if it exists
         // and verify that it belongs to the specified iTwinId
         if(iModelId) {
@@ -60,13 +61,9 @@ export default class SetContext extends BaseCommand {
         // If iTwinId is provided, check if it exists
         else if (iTwinId) {
             await this.runCommand<ITwin>("itwin:info", ["--itwin-id", iTwinId]);
-        }
-        // If neither iModelId nor iTwinId is provided, throw an error
-        else {
-            this.error("Either --itwin-id or --imodel-id must be provided.");
         } 
 
-        const context = await this.setContext(iTwinId, iModelId);
+        const context = await this.setContext(iTwinId!, iModelId);
         return this.logAndReturnResult(context);
     }
 }

--- a/src/extensions/base-command.ts
+++ b/src/extensions/base-command.ts
@@ -258,6 +258,13 @@ export default abstract class BaseCommand extends Command {
     return parsed;
   }
 
+  protected async parseWithoutContext<F extends FlagOutput, B extends FlagOutput, A extends ArgOutput>(
+    options?: Input<F, B, A>,
+    argv?: string[],
+  ): Promise<ParserOutput<F, B, A>> {
+    return super.parse(options, argv);
+  }
+
   protected async runCommand<T>(command: string, args: string[]) : Promise<T> {
     const mergedArgs = [...args, '--silent'];
     return this.config.runCommand<T>(command, mergedArgs);


### PR DESCRIPTION
- This fixes an issue, where `imodel-id` from context is passed to `context set` command, when it is not provided directly to the command.