### PR TITLE
Enforce explicit return types in functions

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,6 +17,11 @@ export default tseslint.config(
     rules: {
       '@stylistic/semi': 'error',
       '@stylistic/indent': ['error', 2],
+      '@typescript-eslint/explicit-function-return-type': ['error', 
+        {
+          "allowedNames": ["tests", "sharedQuickUseCasesParallel"]
+        }
+      ]
     },
     languageOptions: {
       parser: tseslint.parser,

--- a/integration-tests/utils/helpers.ts
+++ b/integration-tests/utils/helpers.ts
@@ -20,7 +20,7 @@ import { FolderTyped } from "../../src/services/storage-client/models/folder-typ
 import { ItemsWithFolderLink } from "../../src/services/storage-client/models/items-with-folder-link.js";
 import { ITP_ISSUER_URL, ITP_MAILINATOR_API_KEY, ITP_NATIVE_TEST_CLIENT_ID, ITP_TEST_USER_EMAIL, ITP_TEST_USER_PASSWORD } from "./environment.js";
 
-export async function serviceLoginToCli() {
+export async function serviceLoginToCli(): Promise<void> {
   const result = await runCommand('auth login');
   expect(result.stdout).to.contain('User successfully logged in using Service login');
 }
@@ -142,7 +142,7 @@ export async function fetchEmailsAndGetInvitationLink(inbox: string, iTwinName: 
   throw new Error("Email was not found in inbox.");
 }
 
-export async function nativeLoginToCli() {
+export async function nativeLoginToCli(): Promise<void> {
   if(isNativeAuthAccessTokenCached())
     return;
 
@@ -156,7 +156,7 @@ export async function nativeLoginToCli() {
   fs.writeFileSync(getTokenPathByOS(), JSON.stringify(authTokenObject), 'utf8');
 }
 
-export async function logoutFromCLI() {
+export async function logoutFromCLI(): Promise<void> {
   const result = await runCommand('auth logout');
   expect(result.stdout).to.contain('User successfully logged out');
 }
@@ -197,7 +197,7 @@ export const isNativeAuthAccessTokenCached = (): boolean => {
   return false;
 };
 
-const getTokenPathByOS = () => {
+const getTokenPathByOS = (): string => {
   switch (os.type()) {
     case 'Linux': {
       const cachePath = `${os.homedir()}/.cache/itp`;
@@ -216,7 +216,7 @@ const getTokenPathByOS = () => {
   }
 };
 
-export const decodeCompressedBase64 = (base64String: string) => {
+export const decodeCompressedBase64 = (base64String: string): string => {
   const buffer = Buffer.from(base64String, "base64");
   return inflate(buffer, {raw: true, to: 'string'});
 };

--- a/integration-tests/utils/mocha-global-setup-native.ts
+++ b/integration-tests/utils/mocha-global-setup-native.ts
@@ -4,7 +4,7 @@ import { expect } from "chai";
 import { AuthInfo } from '../../src/services/synchronizationClient/models/connection-auth';
 import { nativeLoginToCli } from "./helpers";
 
-export async function mochaGlobalSetup() {
+export async function mochaGlobalSetup(): Promise<void> {
   await nativeLoginToCli();
   const { result } = await runCommand<AuthInfo>(`imodel connection auth`);
   expect(result?.isUserAuthorized).to.be.equal(true);

--- a/integration-tests/utils/mocha-global-setup-service.ts
+++ b/integration-tests/utils/mocha-global-setup-service.ts
@@ -1,6 +1,6 @@
 import { logoutFromCLI, serviceLoginToCli } from "./helpers";
 
-export async function mochaGlobalSetup() {
+export async function mochaGlobalSetup(): Promise<void> {
   await logoutFromCLI();
   await serviceLoginToCli();
 

--- a/integration-tests/utils/run-suite-if-main-module.ts
+++ b/integration-tests/utils/run-suite-if-main-module.ts
@@ -12,7 +12,7 @@ import {fileURLToPath} from 'node:url';
  * @param meta `import.meta` object of the current file.
  * @returns `true`, if the current file is not an import, otherwise `false`
  */
-function isMainModule(meta: {url: string}) {
+function isMainModule(meta: {url: string}): boolean {
   for (const arg of process.argv) {
     if(arg.match(/integration-tests(\/|\\).*\.test\.ts/) === null) {
       continue;

--- a/src/commands/access-control/group/create.ts
+++ b/src/commands/access-control/group/create.ts
@@ -8,6 +8,7 @@ import { Flags } from "@oclif/core";
 import { ApiReference } from "../../../extensions/api-reference.js";
 import BaseCommand from "../../../extensions/base-command.js";
 import { customFlags } from "../../../extensions/custom-flags.js";
+import { Group } from "../../../services/access-control-client/models/group.js";
 
 export default class CreateAccessControlGroup extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -42,7 +43,7 @@ export default class CreateAccessControlGroup extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<Group> {
     const { flags } = await this.parse(CreateAccessControlGroup);
   
     const client = await this.getAccessControlApiClient();

--- a/src/commands/access-control/group/delete.ts
+++ b/src/commands/access-control/group/delete.ts
@@ -8,6 +8,7 @@ import { Flags } from "@oclif/core";
 import { ApiReference } from "../../../extensions/api-reference.js";
 import BaseCommand from "../../../extensions/base-command.js";
 import { customFlags } from "../../../extensions/custom-flags.js";
+import { ResultResponse } from "../../../services/general-models/result-response.js";
 
 export default class DeleteAccessControlGroup extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -36,7 +37,7 @@ export default class DeleteAccessControlGroup extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<ResultResponse> {
     const { flags } = await this.parse(DeleteAccessControlGroup);
       
     const client = await this.getAccessControlApiClient();

--- a/src/commands/access-control/group/info.ts
+++ b/src/commands/access-control/group/info.ts
@@ -8,6 +8,7 @@ import { Flags } from "@oclif/core";
 import { ApiReference } from "../../../extensions/api-reference.js";
 import BaseCommand from "../../../extensions/base-command.js";
 import { customFlags } from "../../../extensions/custom-flags.js";
+import { Group } from "../../../services/access-control-client/models/group.js";
 
 export default class AccessControlGroupInfo extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -36,7 +37,7 @@ export default class AccessControlGroupInfo extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<Group> {
     const { flags } = await this.parse(AccessControlGroupInfo);
   
     const client = await this.getAccessControlApiClient();

--- a/src/commands/access-control/group/list.ts
+++ b/src/commands/access-control/group/list.ts
@@ -6,6 +6,7 @@
 import { ApiReference } from "../../../extensions/api-reference.js";
 import BaseCommand from "../../../extensions/base-command.js";
 import { customFlags } from "../../../extensions/custom-flags.js";
+import { Group } from "../../../services/access-control-client/models/group.js";
 
 export default class ListAccessControlGroups extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -28,7 +29,7 @@ export default class ListAccessControlGroups extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<Group[]> {
     const { flags } = await this.parse(ListAccessControlGroups);
   
     const client = await this.getAccessControlApiClient();

--- a/src/commands/access-control/group/update.ts
+++ b/src/commands/access-control/group/update.ts
@@ -8,6 +8,7 @@ import { Flags } from "@oclif/core";
 import { ApiReference } from "../../../extensions/api-reference.js";
 import BaseCommand from "../../../extensions/base-command.js";
 import { customFlags } from "../../../extensions/custom-flags.js";
+import { Group } from "../../../services/access-control-client/models/group.js";
 
 export default class UpdateAccessControlGroup extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -60,7 +61,7 @@ export default class UpdateAccessControlGroup extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<Group> {
     const { flags } = await this.parse(UpdateAccessControlGroup);
    
     if(flags['ims-group'] !== undefined && flags["ims-group"].length > 50) {

--- a/src/commands/access-control/member/group/add.ts
+++ b/src/commands/access-control/member/group/add.ts
@@ -9,7 +9,7 @@ import { ApiReference } from "../../../../extensions/api-reference.js";
 import BaseCommand from "../../../../extensions/base-command.js";
 import { customFlags } from "../../../../extensions/custom-flags.js";
 import { validateUuidCSV } from "../../../../extensions/validation/validate-uuid-csv.js";
-import { GroupMember } from "../../../../services/access-control-client/models/group.js";
+import { GroupMember, GroupMemberInfo } from "../../../../services/access-control-client/models/group.js";
 
 export default class AddGroupMembers extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -57,7 +57,7 @@ export default class AddGroupMembers extends BaseCommand {
     })
   };
 
-  public async run() {
+  public async run(): Promise<GroupMemberInfo[]> {
     const { flags } = await this.parse(AddGroupMembers);
 
     const client = await this.getAccessControlMemberClient();

--- a/src/commands/access-control/member/group/delete.ts
+++ b/src/commands/access-control/member/group/delete.ts
@@ -8,6 +8,7 @@ import { Flags } from "@oclif/core";
 import { ApiReference } from "../../../../extensions/api-reference.js";
 import BaseCommand from "../../../../extensions/base-command.js";
 import { customFlags } from "../../../../extensions/custom-flags.js";
+import { ResultResponse } from "../../../../services/general-models/result-response.js";
 
 export default class DeleteGroupMember extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -36,7 +37,7 @@ export default class DeleteGroupMember extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<ResultResponse> {
     const { flags } = await this.parse(DeleteGroupMember);
   
     const client = await this.getAccessControlMemberClient();

--- a/src/commands/access-control/member/group/info.ts
+++ b/src/commands/access-control/member/group/info.ts
@@ -8,6 +8,7 @@ import { Flags } from "@oclif/core";
 import { ApiReference } from "../../../../extensions/api-reference.js";
 import BaseCommand from "../../../../extensions/base-command.js";
 import { customFlags } from "../../../../extensions/custom-flags.js";
+import { GroupMemberInfo } from "../../../../services/access-control-client/models/group.js";
 
 export default class InfoGroupMember extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -36,7 +37,7 @@ export default class InfoGroupMember extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<GroupMemberInfo> {
     const { flags } = await this.parse(InfoGroupMember);
   
     const client = await this.getAccessControlMemberClient();

--- a/src/commands/access-control/member/group/list.ts
+++ b/src/commands/access-control/member/group/list.ts
@@ -6,6 +6,7 @@
 import { ApiReference } from "../../../../extensions/api-reference.js";
 import BaseCommand from "../../../../extensions/base-command.js";
 import { customFlags } from "../../../../extensions/custom-flags.js";
+import { GroupMemberInfo } from "../../../../services/access-control-client/models/group.js";
 
 export default class ListGroupMembers extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -28,7 +29,7 @@ export default class ListGroupMembers extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<GroupMemberInfo[]> {
     const { flags } = await this.parse(ListGroupMembers);
   
     const client = await this.getAccessControlMemberClient();

--- a/src/commands/access-control/member/group/update.ts
+++ b/src/commands/access-control/member/group/update.ts
@@ -8,6 +8,7 @@ import { Flags } from "@oclif/core";
 import { ApiReference } from "../../../../extensions/api-reference.js";
 import BaseCommand from "../../../../extensions/base-command.js";
 import { customFlags } from "../../../../extensions/custom-flags.js";
+import { GroupMemberInfo } from "../../../../services/access-control-client/models/group.js";
 
 export default class UpdateGroupMember extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -42,7 +43,7 @@ export default class UpdateGroupMember extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<GroupMemberInfo> {
     const { flags } = await this.parse(UpdateGroupMember);
   
     if(flags['role-id'] !== undefined && flags["role-id"].length > 50) {

--- a/src/commands/access-control/member/invitations.ts
+++ b/src/commands/access-control/member/invitations.ts
@@ -6,6 +6,7 @@
 import { ApiReference } from "../../../extensions/api-reference.js";
 import BaseCommand from "../../../extensions/base-command.js";
 import { customFlags } from "../../../extensions/custom-flags.js";
+import { Invitation } from "../../../services/access-control-client/models/invitations.js";
 
 export default class AccessControlMemberInvitations extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -28,7 +29,7 @@ export default class AccessControlMemberInvitations extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<Invitation[]> {
     const { flags } = await this.parse(AccessControlMemberInvitations);
   
     const client = await this.getAccessControlMemberClient();

--- a/src/commands/access-control/member/owner/add.ts
+++ b/src/commands/access-control/member/owner/add.ts
@@ -8,6 +8,7 @@ import { Flags } from "@oclif/core";
 import { ApiReference } from "../../../../extensions/api-reference.js";
 import BaseCommand from "../../../../extensions/base-command.js";
 import { customFlags } from "../../../../extensions/custom-flags.js";
+import { OwnerResponse } from "../../../../services/access-control-client/models/owner.js";
 
 export default class AddOwner extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -35,7 +36,7 @@ export default class AddOwner extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<OwnerResponse> {
     const { flags } = await this.parse(AddOwner);
   
     const client = await this.getAccessControlMemberClient();

--- a/src/commands/access-control/member/owner/delete.ts
+++ b/src/commands/access-control/member/owner/delete.ts
@@ -8,6 +8,7 @@ import { Flags } from "@oclif/core";
 import { ApiReference } from "../../../../extensions/api-reference.js";
 import BaseCommand from "../../../../extensions/base-command.js";
 import { customFlags } from "../../../../extensions/custom-flags.js";
+import { ResultResponse } from "../../../../services/general-models/result-response.js";
 
 export default class DeleteOwner extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -35,7 +36,7 @@ export default class DeleteOwner extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<ResultResponse> {
     const { flags } = await this.parse(DeleteOwner);
   
     const client = await this.getAccessControlMemberClient();

--- a/src/commands/access-control/member/owner/list.ts
+++ b/src/commands/access-control/member/owner/list.ts
@@ -6,6 +6,7 @@
 import { ApiReference } from "../../../../extensions/api-reference.js";
 import BaseCommand from "../../../../extensions/base-command.js";
 import { customFlags } from "../../../../extensions/custom-flags.js";
+import { GroupMember } from "../../../../services/access-control-client/models/group-members.js";
 
 export default class ListOwners extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -28,7 +29,7 @@ export default class ListOwners extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<GroupMember[]> {
     const { flags } = await this.parse(ListOwners);
   
     const client = await this.getAccessControlMemberClient();

--- a/src/commands/access-control/member/user/add.ts
+++ b/src/commands/access-control/member/user/add.ts
@@ -9,7 +9,7 @@ import { ApiReference } from "../../../../extensions/api-reference.js";
 import BaseCommand from "../../../../extensions/base-command.js";
 import { customFlags } from "../../../../extensions/custom-flags.js";
 import { validateUuidCSV } from "../../../../extensions/validation/validate-uuid-csv.js";
-import { UserMember } from "../../../../services/access-control-client/models/members.js";
+import { MembersResponse, UserMember } from "../../../../services/access-control-client/models/members.js";
 
 export default class AddUserMembers extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -63,7 +63,7 @@ export default class AddUserMembers extends BaseCommand {
     })
   };
 
-  public async run() {
+  public async run(): Promise<MembersResponse> {
     const { flags } = await this.parse(AddUserMembers);
 
     const client = await this.getAccessControlMemberClient();

--- a/src/commands/access-control/member/user/delete.ts
+++ b/src/commands/access-control/member/user/delete.ts
@@ -8,6 +8,7 @@ import { Flags } from "@oclif/core";
 import { ApiReference } from "../../../../extensions/api-reference.js";
 import BaseCommand from "../../../../extensions/base-command.js";
 import { customFlags } from "../../../../extensions/custom-flags.js";
+import { ResultResponse } from "../../../../services/general-models/result-response.js";
 
 export default class DeleteUserMember extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -35,7 +36,7 @@ export default class DeleteUserMember extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<ResultResponse> {
     const { flags } = await this.parse(DeleteUserMember);
   
     const client = await this.getAccessControlMemberClient();

--- a/src/commands/access-control/member/user/info.ts
+++ b/src/commands/access-control/member/user/info.ts
@@ -8,6 +8,7 @@ import { Flags } from "@oclif/core";
 import { ApiReference } from "../../../../extensions/api-reference.js";
 import BaseCommand from "../../../../extensions/base-command.js";
 import { customFlags } from "../../../../extensions/custom-flags.js";
+import { Member } from "../../../../services/access-control-client/models/members.js";
 
 export default class InfoUserMember extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -35,7 +36,7 @@ export default class InfoUserMember extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<Member> {
     const { flags } = await this.parse(InfoUserMember);
   
     const client = await this.getAccessControlMemberClient();

--- a/src/commands/access-control/member/user/list.ts
+++ b/src/commands/access-control/member/user/list.ts
@@ -6,6 +6,7 @@
 import { ApiReference } from "../../../../extensions/api-reference.js";
 import BaseCommand from "../../../../extensions/base-command.js";
 import { customFlags } from "../../../../extensions/custom-flags.js";
+import { Member } from "../../../../services/access-control-client/models/members.js";
 
 export default class ListUserMembers extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -28,7 +29,7 @@ export default class ListUserMembers extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<Member[]> {
     const { flags } = await this.parse(ListUserMembers);
   
     const client = await this.getAccessControlMemberClient();

--- a/src/commands/access-control/member/user/update.ts
+++ b/src/commands/access-control/member/user/update.ts
@@ -8,6 +8,7 @@ import { Flags } from "@oclif/core";
 import { ApiReference } from "../../../../extensions/api-reference.js";
 import BaseCommand from "../../../../extensions/base-command.js";
 import { customFlags } from "../../../../extensions/custom-flags.js";
+import { Member } from "../../../../services/access-control-client/models/members.js";
 
 export default class UpdateUserMember extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -41,7 +42,7 @@ export default class UpdateUserMember extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<Member> {
     const { flags } = await this.parse(UpdateUserMember);
   
     if(flags['role-id'] !== undefined && flags["role-id"].length > 50) {

--- a/src/commands/access-control/permissions/all.ts
+++ b/src/commands/access-control/permissions/all.ts
@@ -21,7 +21,7 @@ export default class ListAllPermissions extends BaseCommand {
     }
   ];
 
-  public async run() {
+  public async run(): Promise<string[]> {
     await this.parse(ListAllPermissions);
   
     const client = await this.getAccessControlApiClient();

--- a/src/commands/access-control/permissions/me.ts
+++ b/src/commands/access-control/permissions/me.ts
@@ -28,7 +28,7 @@ export default class MyPermissions extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<string[]> {
     const { flags } = await this.parse(MyPermissions);
   
     const client = await this.getAccessControlApiClient();

--- a/src/commands/access-control/role/create.ts
+++ b/src/commands/access-control/role/create.ts
@@ -8,6 +8,7 @@ import { Flags } from "@oclif/core";
 import { ApiReference } from "../../../extensions/api-reference.js";
 import BaseCommand from "../../../extensions/base-command.js";
 import { customFlags } from "../../../extensions/custom-flags.js";
+import { Role } from "../../../services/access-control-client/models/role.js";
 
 export default class CreateRole extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -42,7 +43,7 @@ export default class CreateRole extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<Role> {
     const { flags } = await this.parse(CreateRole);
   
     const client = await this.getAccessControlApiClient();

--- a/src/commands/access-control/role/delete.ts
+++ b/src/commands/access-control/role/delete.ts
@@ -8,6 +8,7 @@ import { Flags } from "@oclif/core";
 import { ApiReference } from "../../../extensions/api-reference.js";
 import BaseCommand from "../../../extensions/base-command.js";
 import { customFlags } from "../../../extensions/custom-flags.js";
+import { ResultResponse } from "../../../services/general-models/result-response.js";
 
 export default class DeleteRole extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -35,7 +36,7 @@ export default class DeleteRole extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<ResultResponse> {
     const { flags } = await this.parse(DeleteRole);
   
     const client = await this.getAccessControlApiClient();

--- a/src/commands/access-control/role/info.ts
+++ b/src/commands/access-control/role/info.ts
@@ -8,6 +8,7 @@ import { Flags } from "@oclif/core";
 import { ApiReference } from "../../../extensions/api-reference.js";
 import BaseCommand from "../../../extensions/base-command.js";
 import { customFlags } from "../../../extensions/custom-flags.js";
+import { Role } from "../../../services/access-control-client/models/role.js";
 
 export default class InfoRole extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -35,7 +36,7 @@ export default class InfoRole extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<Role> {
     const { flags } = await this.parse(InfoRole);
   
     const client = await this.getAccessControlApiClient();

--- a/src/commands/access-control/role/list.ts
+++ b/src/commands/access-control/role/list.ts
@@ -6,6 +6,7 @@
 import { ApiReference } from "../../../extensions/api-reference.js";
 import BaseCommand from "../../../extensions/base-command.js";
 import { customFlags } from "../../../extensions/custom-flags.js";
+import { Role } from "../../../services/access-control-client/models/role.js";
 
 export default class ListRoles extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -28,7 +29,7 @@ export default class ListRoles extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<Role[]> {
     const { flags } = await this.parse(ListRoles);
   
     const client = await this.getAccessControlApiClient();

--- a/src/commands/access-control/role/update.ts
+++ b/src/commands/access-control/role/update.ts
@@ -8,6 +8,7 @@ import { Flags } from "@oclif/core";
 import { ApiReference } from "../../../extensions/api-reference.js";
 import BaseCommand from "../../../extensions/base-command.js";
 import { customFlags } from "../../../extensions/custom-flags.js";
+import { Role } from "../../../services/access-control-client/models/role.js";
 
 export default class UpdateRole extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -57,7 +58,7 @@ export default class UpdateRole extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<Role> {
     const { flags } = await this.parse(UpdateRole);
   
     const client = await this.getAccessControlApiClient();

--- a/src/commands/api/index.ts
+++ b/src/commands/api/index.ts
@@ -79,7 +79,7 @@ export default class ApiRequest extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<unknown> {
     const { flags } = await this.parse(ApiRequest);
   
     const mappedHeaders: Record<string, string> = flags.header?.reduce((acc, header) => {

--- a/src/commands/auth/info.ts
+++ b/src/commands/auth/info.ts
@@ -4,6 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import BaseCommand from '../../extensions/base-command.js';
+import { AuthorizationInformation } from '../../services/authorization-client/authorization-type.js';
 
 export default class Info extends BaseCommand {
   public static args = {};
@@ -19,7 +20,7 @@ export default class Info extends BaseCommand {
 
   public static flags = {};
 
-  public async run() {    
+  public async run(): Promise<AuthorizationInformation> {    
     const authClient = this.getAuthorizationClient();  
     const authInfo = authClient.info();
     return this.logAndReturnResult(authInfo);

--- a/src/commands/changed-elements/changesets.ts
+++ b/src/commands/changed-elements/changesets.ts
@@ -8,6 +8,7 @@ import { Flags } from "@oclif/core";
 import { ApiReference } from "../../extensions/api-reference.js";
 import BaseCommand from "../../extensions/base-command.js";
 import { customFlags } from "../../extensions/custom-flags.js";
+import { Changeset } from "../../services/changed-elements-client/tracking.js";
 
 export default class GetChangesetStatus extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -49,10 +50,10 @@ export default class GetChangesetStatus extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<Changeset[]> {
     const { flags } = await this.parse(GetChangesetStatus);
   
-    const client = await this.getChangeElementApiClient();
+    const client = await this.getChangedElementsApiClient();
     const result = await client.listChangesets(flags["imodel-id"], flags["itwin-id"], flags.top, flags.skip);
   
     return this.logAndReturnResult(result.changesetStatus);

--- a/src/commands/changed-elements/comparison.ts
+++ b/src/commands/changed-elements/comparison.ts
@@ -8,6 +8,7 @@ import { Flags } from "@oclif/core";
 import { ApiReference } from "../../extensions/api-reference.js";
 import BaseCommand from "../../extensions/base-command.js";
 import { customFlags } from "../../extensions/custom-flags.js";
+import { ChangesetComparison } from "../../services/changed-elements-client/tracking.js";
 
 export default class ChangedElementsComparison extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -47,10 +48,10 @@ export default class ChangedElementsComparison extends BaseCommand {
     })
   };
   
-  public async run() {
+  public async run(): Promise<ChangesetComparison> {
     const { flags } = await this.parse(ChangedElementsComparison);
   
-    const client = await this.getChangeElementApiClient();
+    const client = await this.getChangedElementsApiClient();
     const result = await client.getComparison(flags["itwin-id"], flags["imodel-id"], flags["changeset-id1"], flags["changeset-id2"]);
   
     return this.logAndReturnResult(result.changedElements);

--- a/src/commands/changed-elements/disable.ts
+++ b/src/commands/changed-elements/disable.ts
@@ -6,6 +6,7 @@
 import { ApiReference } from "../../extensions/api-reference.js";
 import BaseCommand from "../../extensions/base-command.js";
 import { customFlags } from "../../extensions/custom-flags.js";
+import { ResultResponse } from "../../services/general-models/result-response.js";
 
 export default class ChangedElementsDisable extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -31,10 +32,10 @@ export default class ChangedElementsDisable extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<ResultResponse> {
     const { flags } = await this.parse(ChangedElementsDisable);
   
-    const client = await this.getChangeElementApiClient();
+    const client = await this.getChangedElementsApiClient();
   
     await client.changeTracking({
       enable: false,

--- a/src/commands/changed-elements/enable.ts
+++ b/src/commands/changed-elements/enable.ts
@@ -6,6 +6,7 @@
 import { ApiReference } from "../../extensions/api-reference.js";
 import BaseCommand from "../../extensions/base-command.js";
 import { customFlags } from "../../extensions/custom-flags.js";
+import { ResultResponse } from "../../services/general-models/result-response.js";
 
 export default class ChangedElementsEnable extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -31,10 +32,10 @@ export default class ChangedElementsEnable extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<ResultResponse> {
     const { flags } = await this.parse(ChangedElementsEnable);
   
-    const client = await this.getChangeElementApiClient();
+    const client = await this.getChangedElementsApiClient();
   
     await client.changeTracking({
       enable: true,

--- a/src/commands/changed-elements/info.ts
+++ b/src/commands/changed-elements/info.ts
@@ -6,6 +6,7 @@
 import { ApiReference } from "../../extensions/api-reference.js";
 import BaseCommand from "../../extensions/base-command.js";
 import { customFlags } from "../../extensions/custom-flags.js";
+import { TrackingResponse } from "../../services/changed-elements-client/tracking.js";
 
 export default class ChangedElementsInfo extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -31,10 +32,10 @@ export default class ChangedElementsInfo extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<TrackingResponse> {
     const { flags } = await this.parse(ChangedElementsInfo);
   
-    const client = await this.getChangeElementApiClient();
+    const client = await this.getChangedElementsApiClient();
     const result = await client.getTracking(flags["imodel-id"], flags["itwin-id"]);
   
     return this.logAndReturnResult(result);

--- a/src/commands/context/clear.ts
+++ b/src/commands/context/clear.ts
@@ -4,6 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import BaseCommand from "../../extensions/base-command.js";
+import { ResultResponse } from "../../services/general-models/result-response.js";
 
 export default class ClearContext extends BaseCommand {
   public static description = "Clear the cached context.";
@@ -15,7 +16,7 @@ export default class ClearContext extends BaseCommand {
     }
   ];
   
-  public async run() {
+  public async run(): Promise<ResultResponse> {
     await this.clearContext();      
     return this.logAndReturnResult({ result: "Context cleared." });
   }

--- a/src/commands/context/info.ts
+++ b/src/commands/context/info.ts
@@ -4,6 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import BaseCommand from "../../extensions/base-command.js";
+import { UserContext } from "../../services/general-models/user-context.js";
 
 export default class InfoContext extends BaseCommand {
   public static description = "Display the cached context.";
@@ -15,7 +16,7 @@ export default class InfoContext extends BaseCommand {
     }
   ];
 
-  public async run() {
+  public async run(): Promise<UserContext | undefined> {
     const context = this.getContext();
     return this.logAndReturnResult(context);
   }

--- a/src/commands/context/set.ts
+++ b/src/commands/context/set.ts
@@ -8,6 +8,7 @@ import { ITwin } from "@itwin/itwins-client";
 import { Flags } from "@oclif/core";
 
 import BaseCommand from "../../extensions/base-command.js";
+import { UserContext } from "../../services/general-models/user-context.js";
 
 export default class SetContext extends BaseCommand {
   public static description = "Set a new cached context. This works by saving iModel and/or iTwin IDs to a file in CLI cache directory.\nNOTE: CLI cache directory can usually be found at: `%LOCALAPPDATA%/itp` on windows, `~/.cache/itp` on UNIX and `~/Library/Caches/itp` on macOS.\nNOTE2: CLI cache directory can be overriden by setting `XDG_CACHE_HOME` environment variable, which is useful in case there is a need to use context in multiple concurrent workflows.";
@@ -43,7 +44,7 @@ export default class SetContext extends BaseCommand {
     }),
   };
 
-  public async run() {
+  public async run(): Promise<UserContext> {
     const { flags } = await this.parseWithoutContext(SetContext);
     const iModelId = flags["imodel-id"];
     let iTwinId = flags["itwin-id"];

--- a/src/commands/docs-generator.ts
+++ b/src/commands/docs-generator.ts
@@ -109,7 +109,7 @@ export default class DocsGenerator extends BaseCommand {
     return returnContent.join("\n\n");
   }
     
-  private async generateDocs(config: Config, basePath: string) {
+  private async generateDocs(config: Config, basePath: string): Promise<void> {
     const filteredCommands = config.commands.filter(c => !c.id.includes("help") && !c.id.includes("plugins") && !c.hidden);
     if(!filteredCommands) {
       return;
@@ -134,7 +134,7 @@ export default class DocsGenerator extends BaseCommand {
     }        
   }
 
-  public async run() {
+  public async run(): Promise<void> {
     const {flags} = await this.parse(DocsGenerator);
 
     const config = await Config.load(
@@ -148,7 +148,7 @@ export default class DocsGenerator extends BaseCommand {
     await this.generateDocs(config, flags["output-dir"] ?? `${config.root}/docs`);
   }
     
-  private writeToFile(filePath: string, markdown: string) {
+  private writeToFile(filePath: string, markdown: string): void {
     const finalPath = `${filePath}.md`;
     this.log(`Writing to directory: ${finalPath}`);
 

--- a/src/commands/imodel/changeset/info.ts
+++ b/src/commands/imodel/changeset/info.ts
@@ -8,6 +8,7 @@ import { Flags } from "@oclif/core";
 import { ApiReference } from "../../../extensions/api-reference.js";
 import BaseCommand from "../../../extensions/base-command.js";
 import { customFlags } from "../../../extensions/custom-flags.js";
+import { Changeset } from "@itwin/imodels-client-management";
 
 export default class ChangesetInfo extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -41,7 +42,7 @@ export default class ChangesetInfo extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<Changeset | undefined> {
     const { flags } = await this.parse(ChangesetInfo);
   
     const client = this.getIModelClient();

--- a/src/commands/imodel/changeset/list.ts
+++ b/src/commands/imodel/changeset/list.ts
@@ -69,7 +69,7 @@ export default class ListChangesets extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<Changeset[]> {
     const { flags } = await this.parse(ListChangesets);
     
     const client = this.getIModelClient();

--- a/src/commands/imodel/connection/auth.ts
+++ b/src/commands/imodel/connection/auth.ts
@@ -8,6 +8,7 @@ import open from 'open';
 
 import { ApiReference } from "../../../extensions/api-reference.js";
 import BaseCommand from "../../../extensions/base-command.js";
+import { AuthInfo } from "../../../services/synchronizationClient/models/connection-auth.js";
 
 export default class ConnectionAuth extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -24,7 +25,7 @@ export default class ConnectionAuth extends BaseCommand {
     }
   ];
 
-  public async run() {
+  public async run(): Promise<AuthInfo> {
     await this.parse(ConnectionAuth);
 
     const client = await this.getSynchronizationClient();

--- a/src/commands/imodel/connection/create.ts
+++ b/src/commands/imodel/connection/create.ts
@@ -12,6 +12,7 @@ import { AuthorizationInformation, AuthorizationType } from "../../../services/a
 import { AuthenticationType } from "../../../services/synchronizationClient/models/authentication-type.js";
 import { ConnectorType } from "../../../services/synchronizationClient/models/connector-type.js";
 import { StorageFileCreate } from "../../../services/synchronizationClient/models/storage-file-create.js";
+import { StorageConnection } from "../../../services/synchronizationClient/models/storage-connection.js";
 
 export default class CreateConnection extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -79,7 +80,7 @@ export default class CreateConnection extends BaseCommand {
     }),
   };
 
-  public async run() {
+  public async run(): Promise<StorageConnection | undefined> {
     const { flags } = await this.parse(CreateConnection);
 
     const client = await this.getSynchronizationClient();

--- a/src/commands/imodel/connection/delete.ts
+++ b/src/commands/imodel/connection/delete.ts
@@ -7,6 +7,7 @@ import { Flags } from "@oclif/core";
 
 import { ApiReference } from "../../../extensions/api-reference.js";
 import BaseCommand from "../../../extensions/base-command.js";
+import { ResultResponse } from "../../../services/general-models/result-response.js";
 
 export default class DeleteConnection extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -32,7 +33,7 @@ export default class DeleteConnection extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<ResultResponse> {
     const { flags } = await this.parse(DeleteConnection);
   
     const client = await this.getSynchronizationClient();

--- a/src/commands/imodel/connection/info.ts
+++ b/src/commands/imodel/connection/info.ts
@@ -7,6 +7,7 @@ import { Flags } from "@oclif/core";
 
 import { ApiReference } from "../../../extensions/api-reference.js";
 import BaseCommand from "../../../extensions/base-command.js";
+import { StorageConnection } from "../../../services/synchronizationClient/models/storage-connection.js";
 
 export default class ConnectionInfo extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -32,7 +33,7 @@ export default class ConnectionInfo extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<StorageConnection | undefined> {
     const { flags } = await this.parse(ConnectionInfo);
   
     const client = await this.getSynchronizationClient();

--- a/src/commands/imodel/connection/list.ts
+++ b/src/commands/imodel/connection/list.ts
@@ -8,6 +8,7 @@ import { Flags } from "@oclif/core";
 import { ApiReference } from "../../../extensions/api-reference.js";
 import BaseCommand from "../../../extensions/base-command.js";
 import { customFlags } from "../../../extensions/custom-flags.js";
+import { StorageConnectionListResponse } from "../../../services/synchronizationClient/models/storage-connection-response.js";
 
 export default class ListConnections extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -48,7 +49,7 @@ export default class ListConnections extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<StorageConnectionListResponse> {
     const { flags } = await this.parse(ListConnections);
   
     const client = await this.getSynchronizationClient();

--- a/src/commands/imodel/connection/run/create.ts
+++ b/src/commands/imodel/connection/run/create.ts
@@ -7,6 +7,7 @@ import { Flags } from "@oclif/core";
 
 import { ApiReference } from "../../../../extensions/api-reference.js";
 import BaseCommand from "../../../../extensions/base-command.js";
+import { ResultResponse } from "../../../../services/general-models/result-response.js";
 
 export default class CreateConnectionRun extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -32,7 +33,7 @@ export default class CreateConnectionRun extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<ResultResponse> {
     const { flags } = await this.parse(CreateConnectionRun);
   
     const client = await this.getSynchronizationClient();

--- a/src/commands/imodel/connection/run/info.ts
+++ b/src/commands/imodel/connection/run/info.ts
@@ -7,6 +7,7 @@ import { Flags } from "@oclif/core";
 
 import { ApiReference } from "../../../../extensions/api-reference.js";
 import BaseCommand from "../../../../extensions/base-command.js";
+import { StorageRun } from "../../../../services/synchronizationClient/models/storage-run.js";
 
 export default class ConnectionRunInfo extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -36,7 +37,7 @@ export default class ConnectionRunInfo extends BaseCommand {
       required: true }),
   };
   
-  public async run() {
+  public async run(): Promise<StorageRun | undefined> {
     const { flags } = await this.parse(ConnectionRunInfo);
   
     const client = await this.getSynchronizationClient();

--- a/src/commands/imodel/connection/run/list.ts
+++ b/src/commands/imodel/connection/run/list.ts
@@ -7,6 +7,7 @@ import { Flags } from "@oclif/core";
 
 import { ApiReference } from "../../../../extensions/api-reference.js";
 import BaseCommand from "../../../../extensions/base-command.js";
+import { StorageRunsResponse } from "../../../../services/synchronizationClient/models/storage-run-response.js";
 
 export default class ConnectionRunsListed extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -48,7 +49,7 @@ export default class ConnectionRunsListed extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<StorageRunsResponse> {
     const { flags } = await this.parse(ConnectionRunsListed);
   
     const client = await this.getSynchronizationClient();

--- a/src/commands/imodel/connection/sourcefile/add.ts
+++ b/src/commands/imodel/connection/sourcefile/add.ts
@@ -8,6 +8,7 @@ import { Flags } from "@oclif/core";
 import { ApiReference } from "../../../../extensions/api-reference.js";
 import BaseCommand from "../../../../extensions/base-command.js";
 import { ConnectorType } from "../../../../services/synchronizationClient/models/connector-type.js";
+import { SourceFile } from "../../../../services/synchronizationClient/models/source-file.js";
 
 export default class CreateConnectionSourceFile extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -59,7 +60,7 @@ export default class CreateConnectionSourceFile extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<SourceFile> {
     const { flags } = await this.parse(CreateConnectionSourceFile);
   
     const client = await this.getSynchronizationClient();

--- a/src/commands/imodel/connection/sourcefile/delete.ts
+++ b/src/commands/imodel/connection/sourcefile/delete.ts
@@ -7,6 +7,7 @@ import { Flags } from "@oclif/core";
 
 import { ApiReference } from "../../../../extensions/api-reference.js";
 import BaseCommand from "../../../../extensions/base-command.js";
+import { ResultResponse } from "../../../../services/general-models/result-response.js";
 
 export default class ConnectionSourceFileDelete extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -37,7 +38,7 @@ export default class ConnectionSourceFileDelete extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<ResultResponse> {
     const { flags } = await this.parse(ConnectionSourceFileDelete);
   
     const client = await this.getSynchronizationClient();

--- a/src/commands/imodel/connection/sourcefile/info.ts
+++ b/src/commands/imodel/connection/sourcefile/info.ts
@@ -7,6 +7,7 @@ import { Flags } from "@oclif/core";
 
 import { ApiReference } from "../../../../extensions/api-reference.js";
 import BaseCommand from "../../../../extensions/base-command.js";
+import { SourceFile } from "../../../../services/synchronizationClient/models/source-file.js";
 
 export default class ConnectionSourceFileInfo extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -37,7 +38,7 @@ export default class ConnectionSourceFileInfo extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<SourceFile> {
     const { flags } = await this.parse(ConnectionSourceFileInfo);
   
     const client = await this.getSynchronizationClient();

--- a/src/commands/imodel/connection/sourcefile/list.ts
+++ b/src/commands/imodel/connection/sourcefile/list.ts
@@ -7,6 +7,7 @@ import { Flags } from "@oclif/core";
 
 import { ApiReference } from "../../../../extensions/api-reference.js";
 import BaseCommand from "../../../../extensions/base-command.js";
+import { SourceFile } from "../../../../services/synchronizationClient/models/source-file.js";
 
 export default class ListSourceFiles extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -48,7 +49,7 @@ export default class ListSourceFiles extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<SourceFile[]> {
     const { flags } = await this.parse(ListSourceFiles);
   
     const client = await this.getSynchronizationClient();

--- a/src/commands/imodel/connection/sourcefile/update.ts
+++ b/src/commands/imodel/connection/sourcefile/update.ts
@@ -8,6 +8,7 @@ import { Flags } from "@oclif/core";
 import { ApiReference } from "../../../../extensions/api-reference.js";
 import BaseCommand from "../../../../extensions/base-command.js";
 import { ConnectorType } from "../../../../services/synchronizationClient/models/connector-type.js";
+import { SourceFile } from "../../../../services/synchronizationClient/models/source-file.js";
 
 export default class ConnectionSourceFileUpdate extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -64,7 +65,7 @@ export default class ConnectionSourceFileUpdate extends BaseCommand {
     })
   };
   
-  public async run() {
+  public async run(): Promise<SourceFile> {
     const { flags } = await this.parse(ConnectionSourceFileUpdate);
   
     const client = await this.getSynchronizationClient();

--- a/src/commands/imodel/connection/update.ts
+++ b/src/commands/imodel/connection/update.ts
@@ -8,6 +8,7 @@ import { Flags } from "@oclif/core";
 import { ApiReference } from "../../../extensions/api-reference.js";
 import BaseCommand from "../../../extensions/base-command.js";
 import { AuthenticationType } from "../../../services/synchronizationClient/models/authentication-type.js";
+import { StorageConnection } from "../../../services/synchronizationClient/models/storage-connection.js";
 
 export default class UpdateStorageConnection extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -49,7 +50,7 @@ export default class UpdateStorageConnection extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<StorageConnection | undefined> {
     const { flags } = await this.parse(UpdateStorageConnection);
   
     const client = await this.getSynchronizationClient();

--- a/src/commands/imodel/create.ts
+++ b/src/commands/imodel/create.ts
@@ -9,6 +9,7 @@ import { ApiReference } from "../../extensions/api-reference.js";
 import BaseCommand from "../../extensions/base-command.js";
 import { customFlags } from "../../extensions/custom-flags.js";
 import { validateFloat } from "../../extensions/validation/validate-float.js";
+import { IModel } from "@itwin/imodels-client-management";
 
 export default class CreateIModel extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -103,7 +104,7 @@ export default class CreateIModel extends BaseCommand {
     }),
   };
 
-  public async run() {
+  public async run(): Promise<IModel> {
     const { flags } = await this.parse(CreateIModel);
     
     if(flags["ne-latitude"] !== undefined && flags["ne-longitude"] !== undefined && flags["sw-latitude"] !== undefined && flags["sw-longitude"] !== undefined) {

--- a/src/commands/imodel/delete.ts
+++ b/src/commands/imodel/delete.ts
@@ -6,6 +6,7 @@
 import { ApiReference } from "../../extensions/api-reference.js";
 import BaseCommand from "../../extensions/base-command.js";
 import { customFlags } from "../../extensions/custom-flags.js";
+import { ResultResponse } from "../../services/general-models/result-response.js";
 
 export default class DeleteIModel extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -28,7 +29,7 @@ export default class DeleteIModel extends BaseCommand {
     }),
   };
 
-  public async run() {
+  public async run(): Promise<ResultResponse> {
     const { flags } = await this.parse(DeleteIModel);
 
     const client = this.getIModelClient();

--- a/src/commands/imodel/info.ts
+++ b/src/commands/imodel/info.ts
@@ -3,6 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
+import { IModel } from "@itwin/imodels-client-management";
 import { ApiReference } from "../../extensions/api-reference.js";
 import BaseCommand from "../../extensions/base-command.js";
 import { customFlags } from "../../extensions/custom-flags.js";
@@ -28,7 +29,7 @@ export class IModelInfo extends BaseCommand {
     }),
   };
 
-  public async run() {
+  public async run(): Promise<IModel> {
     const { flags } = await this.parse(IModelInfo);
     
     const iModelClient = this.getIModelClient();

--- a/src/commands/imodel/list.ts
+++ b/src/commands/imodel/list.ts
@@ -75,7 +75,7 @@ export default class ListIModels extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<IModel[]> {
     const { flags } = await this.parse(ListIModels);
   
     const client = this.getIModelClient();

--- a/src/commands/imodel/named-version/create.ts
+++ b/src/commands/imodel/named-version/create.ts
@@ -8,6 +8,7 @@ import { Flags } from "@oclif/core";
 import { ApiReference } from "../../../extensions/api-reference.js";
 import BaseCommand from "../../../extensions/base-command.js";
 import { customFlags } from "../../../extensions/custom-flags.js";
+import { NamedVersion } from "@itwin/imodels-client-management";
 
 export default class CreateNamedVersion extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -55,7 +56,7 @@ export default class CreateNamedVersion extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<NamedVersion> {
     const { flags } = await this.parse(CreateNamedVersion);
   
     const client = this.getIModelClient();

--- a/src/commands/imodel/named-version/info.ts
+++ b/src/commands/imodel/named-version/info.ts
@@ -8,6 +8,7 @@ import { Flags } from "@oclif/core";
 import { ApiReference } from "../../../extensions/api-reference.js";
 import BaseCommand from "../../../extensions/base-command.js";
 import { customFlags } from "../../../extensions/custom-flags.js";
+import { NamedVersion } from "@itwin/imodels-client-management";
 
 export default class NamedVersionInfo extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -35,7 +36,7 @@ export default class NamedVersionInfo extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<NamedVersion> {
     const { flags } = await this.parse(NamedVersionInfo);
   
     const client = this.getIModelClient();

--- a/src/commands/imodel/named-version/list.ts
+++ b/src/commands/imodel/named-version/list.ts
@@ -69,7 +69,7 @@ export default class ListNamedVersions extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<NamedVersion[]> {
     const { flags } = await this.parse(ListNamedVersions);
   
     const client = this.getIModelClient();

--- a/src/commands/imodel/populate.ts
+++ b/src/commands/imodel/populate.ts
@@ -93,7 +93,7 @@ export default class PopulateIModel extends BaseCommand {
     }),
   };
 
-  public async run() {
+  public async run(): Promise<PopulateResponse> {
     const { flags } = await this.parse(PopulateIModel);
 
     if(flags["connector-type"] && flags["connector-type"].length !== 1 && flags.file.length !== flags["connector-type"].length) {
@@ -158,7 +158,7 @@ export default class PopulateIModel extends BaseCommand {
     return populateResponse;
   }
 
-  private async addFileToConnectionIfItIsNotPresent(connectionId: string, sourceFiles: SourceFile[], file: { connectorType: ConnectorType, fileId: string, fileName: string }) {
+  private async addFileToConnectionIfItIsNotPresent(connectionId: string, sourceFiles: SourceFile[], file: { connectorType: ConnectorType, fileId: string, fileName: string }): Promise<void> {
     const fileExist = sourceFiles.find(f => f.storageFileId === file.fileId);
     if (!fileExist) {
       this.log(`Adding file: ${file.fileId} to default connection: ${connectionId}`);

--- a/src/commands/imodel/update.ts
+++ b/src/commands/imodel/update.ts
@@ -9,6 +9,7 @@ import { ApiReference } from "../../extensions/api-reference.js";
 import BaseCommand from "../../extensions/base-command.js";
 import { customFlags } from "../../extensions/custom-flags.js";
 import { validateFloat } from "../../extensions/validation/validate-float.js";
+import { IModel } from "@itwin/imodels-client-management";
 
 export default class UpdateCommand extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -95,7 +96,7 @@ export default class UpdateCommand extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<IModel> {
     const { flags } = await this.parse(UpdateCommand);
   
     if(flags["ne-latitude"] !== undefined && flags["ne-longitude"] !== undefined && flags["sw-latitude"] !== undefined && flags["sw-longitude"] !== undefined) {

--- a/src/commands/imodel/view/cesium-sandcastle.ts
+++ b/src/commands/imodel/view/cesium-sandcastle.ts
@@ -123,7 +123,7 @@ export default class CesiumSandcastle extends BaseCommand {
     return newExport;
   }
 
-  public async run() {
+  public async run(): Promise<{url: string;}> {
     const { flags } = await this.parse(CesiumSandcastle);
 
     let changesetId = flags["changeset-id"] ?? "";

--- a/src/commands/itwin/create.ts
+++ b/src/commands/itwin/create.ts
@@ -97,7 +97,7 @@ export default class CreateITwin extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<ITwin | undefined> {
     const { flags } = await this.parse(CreateITwin);
   
     const iTwin : ITwin = {

--- a/src/commands/itwin/delete.ts
+++ b/src/commands/itwin/delete.ts
@@ -6,6 +6,7 @@
 import { ApiReference } from "../../extensions/api-reference.js";
 import BaseCommand from "../../extensions/base-command.js";
 import { customFlags } from "../../extensions/custom-flags.js";
+import { ResultResponse } from "../../services/general-models/result-response.js";
 
 export default class DeleteITwin extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -28,7 +29,7 @@ export default class DeleteITwin extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<ResultResponse> {
     const { flags } = await this.parse(DeleteITwin);  
       
     const accessToken = await this.getAccessToken();

--- a/src/commands/itwin/info.ts
+++ b/src/commands/itwin/info.ts
@@ -3,6 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
+import { ITwin } from "@itwin/itwins-client";
 import { ApiReference } from "../../extensions/api-reference.js";
 import BaseCommand from "../../extensions/base-command.js";
 import { customFlags } from "../../extensions/custom-flags.js";
@@ -28,7 +29,7 @@ export default class ITwinInfo extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<ITwin | undefined> {
     const { flags } = await this.parse(ITwinInfo);
     
     const accessToken = await this.getAccessToken();

--- a/src/commands/itwin/list.ts
+++ b/src/commands/itwin/list.ts
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import { ITwinSubClass } from "@itwin/itwins-client";
+import { ITwin, ITwinSubClass } from "@itwin/itwins-client";
 import { Flags } from "@oclif/core";
 
 import { ApiReference } from "../../extensions/api-reference.js";
@@ -101,7 +101,7 @@ export default class ListITwins extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<ITwin[] | undefined> {
     const { flags } = await this.parse(ListITwins);
   
     const accessToken = await this.getAccessToken();

--- a/src/commands/itwin/repository/create.ts
+++ b/src/commands/itwin/repository/create.ts
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import { RepositoryClass, RepositorySubClass } from "@itwin/itwins-client";
+import { Repository, RepositoryClass, RepositorySubClass } from "@itwin/itwins-client";
 import { Flags } from "@oclif/core";
 
 import { ApiReference } from "../../../extensions/api-reference.js";
@@ -55,7 +55,7 @@ export default class CreateRepository extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<Repository | undefined> {
     const { flags } = await this.parse(CreateRepository);
   
     const accessToken = await this.getAccessToken();

--- a/src/commands/itwin/repository/delete.ts
+++ b/src/commands/itwin/repository/delete.ts
@@ -8,6 +8,7 @@ import { Flags } from "@oclif/core";
 import { ApiReference } from "../../../extensions/api-reference.js";
 import BaseCommand from "../../../extensions/base-command.js";
 import { customFlags } from "../../../extensions/custom-flags.js";
+import { ResultResponse } from "../../../services/general-models/result-response.js";
 
 export default class DeleteRepository extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -35,7 +36,7 @@ export default class DeleteRepository extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<ResultResponse> {
     const { flags } = await this.parse(DeleteRepository);
   
     const client = this.getITwinAccessClient();

--- a/src/commands/itwin/repository/list.ts
+++ b/src/commands/itwin/repository/list.ts
@@ -8,6 +8,7 @@ import { Flags } from "@oclif/core";
 import { ApiReference } from "../../../extensions/api-reference.js";
 import BaseCommand from "../../../extensions/base-command.js";
 import { customFlags } from "../../../extensions/custom-flags.js";
+import { Repository } from "@itwin/itwins-client";
 
 export default class ListRepositories extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -50,7 +51,7 @@ export default class ListRepositories extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<Repository[] | undefined> {
     const { flags } = await this.parse(ListRepositories);
   
     const client = this.getITwinAccessClient();

--- a/src/commands/itwin/update.ts
+++ b/src/commands/itwin/update.ts
@@ -72,7 +72,7 @@ export default class UpdateCommand extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<ITwin | undefined> {
     const { flags } = await this.parse(UpdateCommand);
   
     const iTwinUpdate : ITwin = {

--- a/src/commands/storage/file/create.ts
+++ b/src/commands/storage/file/create.ts
@@ -7,6 +7,7 @@ import { Flags } from "@oclif/core";
 
 import { ApiReference } from "../../../extensions/api-reference.js";
 import BaseCommand from "../../../extensions/base-command.js";
+import { FileUpload } from "../../../services/storage-client/models/file-upload.js";
 
 export default class FileCreate extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -48,7 +49,7 @@ export default class FileCreate extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<FileUpload> {
     const { flags } = await this.parse(FileCreate);
   
     const client = await this.getStorageApiClient();

--- a/src/commands/storage/file/delete.ts
+++ b/src/commands/storage/file/delete.ts
@@ -7,6 +7,7 @@ import { Flags } from "@oclif/core";
 
 import { ApiReference } from "../../../extensions/api-reference.js";
 import BaseCommand from "../../../extensions/base-command.js";
+import { ResultResponse } from "../../../services/general-models/result-response.js";
 
 export default class DeleteFile extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -32,7 +33,7 @@ export default class DeleteFile extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<ResultResponse> {
     const { flags } = await this.parse(DeleteFile);
   
     const client = await this.getStorageApiClient();

--- a/src/commands/storage/file/info.ts
+++ b/src/commands/storage/file/info.ts
@@ -7,6 +7,7 @@ import { Flags } from "@oclif/core";
 
 import { ApiReference } from "../../../extensions/api-reference.js";
 import BaseCommand from "../../../extensions/base-command.js";
+import { FileTyped } from "../../../services/storage-client/models/file-typed.js";
 
 export default class FileInfo extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -32,7 +33,7 @@ export default class FileInfo extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<FileTyped | undefined> {
     const { flags } = await this.parse(FileInfo);
   
     const client = await this.getStorageApiClient();

--- a/src/commands/storage/file/list.ts
+++ b/src/commands/storage/file/list.ts
@@ -7,6 +7,7 @@ import { Flags } from "@oclif/core";
 
 import { ApiReference } from "../../../extensions/api-reference.js";
 import BaseCommand from "../../../extensions/base-command.js";
+import { FileTyped } from "../../../services/storage-client/models/file-typed.js";
 
 export default class ListFiles extends BaseCommand {
   public static apiReference: ApiReference[] = [
@@ -45,7 +46,7 @@ export default class ListFiles extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<FileTyped[]> {
     const { flags } = await this.parse(ListFiles);
   
     const client = await this.getStorageApiClient();

--- a/src/commands/storage/file/update-complete.ts
+++ b/src/commands/storage/file/update-complete.ts
@@ -7,6 +7,7 @@ import { Flags } from "@oclif/core";
 
 import { ApiReference } from "../../../extensions/api-reference.js";
 import BaseCommand from "../../../extensions/base-command.js";
+import { FileTyped } from "../../../services/storage-client/models/file-typed.js";
 
 export default class FileUpdateComplete extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -32,7 +33,7 @@ export default class FileUpdateComplete extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<FileTyped | undefined> {
     const { flags } = await this.parse(FileUpdateComplete);
   
     const client = await this.getStorageApiClient();

--- a/src/commands/storage/file/update-content.ts
+++ b/src/commands/storage/file/update-content.ts
@@ -7,6 +7,7 @@ import { Flags } from "@oclif/core";
 
 import { ApiReference } from "../../../extensions/api-reference.js";
 import BaseCommand from "../../../extensions/base-command.js";
+import { FileUpload } from "../../../services/storage-client/models/file-upload.js";
 
 export default class UpdateContent extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -32,7 +33,7 @@ export default class UpdateContent extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<FileUpload> {
     const { flags } = await this.parse(UpdateContent);
 
     const storageApiClient = await this.getStorageApiClient();

--- a/src/commands/storage/file/update.ts
+++ b/src/commands/storage/file/update.ts
@@ -7,6 +7,7 @@ import { Flags } from "@oclif/core";
 
 import { ApiReference } from "../../../extensions/api-reference.js";
 import BaseCommand from "../../../extensions/base-command.js";
+import { FileTyped } from "../../../services/storage-client/models/file-typed.js";
 
 export default class UpdateCommand extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -46,7 +47,7 @@ export default class UpdateCommand extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<FileTyped | undefined> {
     const { flags } = await this.parse(UpdateCommand);
   
     const client = await this.getStorageApiClient();

--- a/src/commands/storage/file/upload.ts
+++ b/src/commands/storage/file/upload.ts
@@ -8,6 +8,7 @@ import fs from "node:fs";
 
 import BaseCommand from "../../../extensions/base-command.js";
 import { ApiReference } from "../../../extensions/api-reference.js";
+import { ResultResponse } from "../../../services/general-models/result-response.js";
 
 export default class FileUpload extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -43,7 +44,7 @@ export default class FileUpload extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<ResultResponse> {
     const { flags } = await this.parse(FileUpload);
   
     const client = await this.getStorageApiClient();
@@ -60,7 +61,7 @@ export default class FileUpload extends BaseCommand {
     return this.logAndReturnResult(returnObject);
   }
   
-  private toArrayBuffer(buffer: Buffer) {
+  private toArrayBuffer(buffer: Buffer): ArrayBuffer {
     const arrayBuffer = new ArrayBuffer(buffer.length);
     const view = new Uint8Array(arrayBuffer);
     for (const [i, element] of buffer.entries()) {

--- a/src/commands/storage/folder/create.ts
+++ b/src/commands/storage/folder/create.ts
@@ -7,6 +7,7 @@ import { Flags } from "@oclif/core";
 
 import { ApiReference } from "../../../extensions/api-reference.js";
 import BaseCommand from "../../../extensions/base-command.js";
+import { FolderTyped } from "../../../services/storage-client/models/folder-typed.js";
 
 export default class CreateFolder extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -46,7 +47,7 @@ export default class CreateFolder extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<FolderTyped> {
     const { flags } = await this.parse(CreateFolder);
   
     const client = await this.getStorageApiClient();

--- a/src/commands/storage/folder/delete.ts
+++ b/src/commands/storage/folder/delete.ts
@@ -7,6 +7,7 @@ import { Flags } from "@oclif/core";
 
 import { ApiReference } from "../../../extensions/api-reference.js";
 import BaseCommand from "../../../extensions/base-command.js";
+import { ResultResponse } from "../../../services/general-models/result-response.js";
 
 export default class DeleteFolder extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -32,7 +33,7 @@ export default class DeleteFolder extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<ResultResponse> {
     const { flags } = await this.parse(DeleteFolder);
   
     const client = await this.getStorageApiClient();

--- a/src/commands/storage/folder/info.ts
+++ b/src/commands/storage/folder/info.ts
@@ -7,6 +7,7 @@ import { Flags } from "@oclif/core";
 
 import { ApiReference } from "../../../extensions/api-reference.js";
 import BaseCommand from "../../../extensions/base-command.js";
+import { FolderTyped } from "../../../services/storage-client/models/folder-typed.js";
 
 export default class FolderInfo extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -32,7 +33,7 @@ export default class FolderInfo extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<FolderTyped> {
     const { flags } = await this.parse(FolderInfo);
   
     const client = await this.getStorageApiClient();

--- a/src/commands/storage/folder/list.ts
+++ b/src/commands/storage/folder/list.ts
@@ -7,6 +7,8 @@ import { Flags } from "@oclif/core";
 
 import { ApiReference } from "../../../extensions/api-reference.js";
 import BaseCommand from "../../../extensions/base-command.js";
+import { FileTyped } from "../../../services/storage-client/models/file-typed.js";
+import { FolderTyped } from "../../../services/storage-client/models/folder-typed.js";
 
 export default class ListFolders extends BaseCommand {
   public static apiReference: ApiReference[] = [
@@ -45,7 +47,7 @@ export default class ListFolders extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<FileTyped[] | FolderTyped[]> {
     const { flags } = await this.parse(ListFolders);
   
     const client = await this.getStorageApiClient();

--- a/src/commands/storage/folder/update.ts
+++ b/src/commands/storage/folder/update.ts
@@ -7,6 +7,7 @@ import { Flags } from "@oclif/core";
 
 import { ApiReference } from "../../../extensions/api-reference.js";
 import BaseCommand from "../../../extensions/base-command.js";
+import { FolderTyped } from "../../../services/storage-client/models/folder-typed.js";
 
 export default class UpdateFolder extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -46,7 +47,7 @@ export default class UpdateFolder extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<FolderTyped> {
     const { flags } = await this.parse(UpdateFolder);
   
     const client = await this.getStorageApiClient();

--- a/src/commands/storage/root-folder.ts
+++ b/src/commands/storage/root-folder.ts
@@ -8,6 +8,7 @@ import { Flags } from '@oclif/core';
 import BaseCommand from '../../extensions/base-command.js';
 import { customFlags } from '../../extensions/custom-flags.js';
 import { ApiReference } from '../../extensions/api-reference.js';
+import { ItemsWithFolderLink } from '../../services/storage-client/models/items-with-folder-link.js';
 
 export default class GetRootFolder extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -40,7 +41,7 @@ export default class GetRootFolder extends BaseCommand {
     }),
   };
 
-  public async run() {
+  public async run(): Promise<ItemsWithFolderLink> {
     const { flags } = await this.parse(GetRootFolder);
     
     const client = await this.getStorageApiClient();

--- a/src/commands/user/info.ts
+++ b/src/commands/user/info.ts
@@ -7,6 +7,7 @@ import { Flags } from "@oclif/core";
 
 import { ApiReference } from "../../extensions/api-reference.js";
 import BaseCommand from "../../extensions/base-command.js";
+import { User } from "../../services/user-client/models/user.js";
 
 export default class UserInfo extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -32,7 +33,7 @@ export default class UserInfo extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<User[]> {
     const { flags } = await this.parse(UserInfo);
   
     if(flags["user-id"] !== undefined && flags["user-id"].length > 1000) {

--- a/src/commands/user/me.ts
+++ b/src/commands/user/me.ts
@@ -5,6 +5,7 @@
 
 import { ApiReference } from "../../extensions/api-reference.js"; // Added import
 import BaseCommand from "../../extensions/base-command.js";
+import { User } from "../../services/user-client/models/user.js";
 
 export default class Me extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -25,7 +26,7 @@ export default class Me extends BaseCommand {
 
   public static flags = {};
 
-  public async run() {
+  public async run(): Promise<User> {
     const userApiClient = await this.getUserApiClient();
     const userInfo = await userApiClient.getMe();
 

--- a/src/commands/user/search.ts
+++ b/src/commands/user/search.ts
@@ -7,6 +7,7 @@ import { Flags } from "@oclif/core";
 
 import { ApiReference } from "../../extensions/api-reference.js";
 import BaseCommand from "../../extensions/base-command.js";
+import { User } from "../../services/user-client/models/user.js";
 
 export default class UserSearch extends BaseCommand {
   public static apiReference: ApiReference = {
@@ -35,7 +36,7 @@ export default class UserSearch extends BaseCommand {
     }),
   };
   
-  public async run() {
+  public async run(): Promise<User[]> {
     const { flags } = await this.parse(UserSearch);
   
     const client = await this.getUserApiClient();

--- a/src/extensions/base-command.ts
+++ b/src/extensions/base-command.ts
@@ -48,7 +48,7 @@ export default abstract class BaseCommand extends Command {
 
   public static enableJsonFlag = true;
 
-  protected async clearContext() {
+  protected async clearContext(): Promise<void> {
     const contextPath = `${this.config.cacheDir  }/context.json`;
     if (fs.existsSync(contextPath)) {
       fs.rmSync(contextPath, { force: true });
@@ -57,13 +57,13 @@ export default abstract class BaseCommand extends Command {
     this.debug(`Cleared context file: ${contextPath}`);
   }
 
-  protected async getAccessControlApiClient() {
+  protected async getAccessControlApiClient(): Promise<AccessControlClient> {
     const token = await this.getAccessToken();
     const url = this.getBaseApiUrl();
     return new AccessControlClient(url, token);
   }
 
-  protected async getAccessControlMemberClient(){
+  protected async getAccessControlMemberClient(): Promise<AccessControlMemberClient> {
     const token = this.getAccessToken();
     const url = this.getBaseApiUrl();
     
@@ -90,16 +90,16 @@ export default abstract class BaseCommand extends Command {
     });
   }
 
-  protected getAuthorizationClient() {
+  protected getAuthorizationClient(): AuthorizationClient {
     return new AuthorizationClient(this.getConfig(), this.config);
   }
 
-  protected getBaseApiUrl() {
+  protected getBaseApiUrl(): string {
     const config = this.getConfig();
     return config?.apiUrl ?? 'https://api.bentley.com';
   }
 
-  protected async getChangeElementApiClient() {
+  protected async getChangedElementsApiClient(): Promise<ChangedElementsApiClient> {
     return new ChangedElementsApiClient(await this.getITwinApiClient());
   }
 
@@ -192,15 +192,15 @@ export default abstract class BaseCommand extends Command {
     return context?.iTwinId;
   }
 
-  protected async getStorageApiClient() {
+  protected async getStorageApiClient(): Promise<StorageApiClient> {
     return new StorageApiClient(await this.getITwinApiClient());
   }
 
-  protected async getSynchronizationClient() {
+  protected async getSynchronizationClient(): Promise<SynchronizationApiClient> {
     return new SynchronizationApiClient(await this.getITwinApiClient());
   }
 
-  protected async getUserApiClient() {
+  protected async getUserApiClient(): Promise<UserApiClient> {
     return new UserApiClient(await this.getITwinApiClient());
   }
 
@@ -218,7 +218,7 @@ export default abstract class BaseCommand extends Command {
     return result;
   }
 
-  protected logTable<T>(data: T) {
+  protected logTable<T>(data: T): void {
     if(Array.isArray(data))
     {
       const table = new Table();
@@ -270,7 +270,7 @@ export default abstract class BaseCommand extends Command {
     return this.config.runCommand<T>(command, mergedArgs);
   }
 
-  protected async setContext(iTwinId: string, iModelId?: string) {
+  protected async setContext(iTwinId: string, iModelId?: string): Promise<UserContext> {
     const contextPath = `${this.config.cacheDir  }/context.json`;
     
     const context: UserContext = {

--- a/src/extensions/custom-flags.ts
+++ b/src/extensions/custom-flags.ts
@@ -9,18 +9,19 @@ import extent from "./custom-flags/extent.js";
 import groupMembers from "./custom-flags/group-member-array.js";
 import noSchemaJson from "./custom-flags/no-schema-json.js";
 import userMembers from "./custom-flags/user-member-array.js";
+import { CustomOptions, OptionFlag } from "@oclif/core/interfaces";
 
 export const customFlags = {
   extent,
   groupMembers,
-  iModelIDFlag: (config : CustomFlagConfig) => Flags.string({
+  iModelIDFlag: (config : CustomFlagConfig): OptionFlag<string, CustomOptions> => Flags.string({
     char: 'm',
     description: config.description,
     env: 'ITP_IMODEL_ID',
     helpValue: '<string>',
     required: true,
   }),
-  iTwinIDFlag: (config : CustomFlagConfig) => Flags.string({ 
+  iTwinIDFlag: (config : CustomFlagConfig): OptionFlag<string, CustomOptions> => Flags.string({ 
     char: 'i', 
     description: config.description,
     env: 'ITP_ITWIN_ID',

--- a/src/services/authorization-client/authorization-client.ts
+++ b/src/services/authorization-client/authorization-client.ts
@@ -66,7 +66,7 @@ export class AuthorizationClient {
     return this.saveAccessToken(usedToken, authType);
   }
 
-  public async logout() {
+  public async logout(): Promise<void> {
     const existingTokenInfo = this.getExistingAuthTokenInfo();
 
     // Login from IMS
@@ -97,7 +97,7 @@ export class AuthorizationClient {
     }
   }
 
-  private async getAccessTokenFromService(clientId: string, clientSecret: string, issuerUrl: string) {
+  private async getAccessTokenFromService(clientId: string, clientSecret: string, issuerUrl: string): Promise<string> {
     const client = new ServiceAuthorizationClient({
       authority: issuerUrl,
       clientId,
@@ -108,7 +108,7 @@ export class AuthorizationClient {
     return client.getAccessToken();
   }
 
-  private async getAccessTokenFromWebsiteLogin(clientId: string, issuerUrl: string) {
+  private async getAccessTokenFromWebsiteLogin(clientId: string, issuerUrl: string): Promise<string> {
     const client = new NodeCliAuthorizationClient({
       clientId,
       expiryBuffer: 10 * 60,
@@ -122,7 +122,7 @@ export class AuthorizationClient {
     return client.getAccessToken();    
   }
 
-  private getExistingAuthTokenInfo() {
+  private getExistingAuthTokenInfo(): AuthTokenInfo | undefined {
     const tokenPath = path.join(this._cliConfiguration.cacheDir, 'token.json');
 
     if (!fs.existsSync(tokenPath)) {
@@ -132,7 +132,7 @@ export class AuthorizationClient {
     return JSON.parse(fs.readFileSync(tokenPath, 'utf8')) as AuthTokenInfo;
   }
 
-  private isExpirationDateValid(expirationDate: Date | undefined)  {
+  private isExpirationDateValid(expirationDate: Date | undefined): boolean {
     if(!expirationDate) {
       return false;
     }
@@ -145,7 +145,7 @@ export class AuthorizationClient {
     return expirationDateFixed > currentDate;      
   }
 
-  private saveAccessToken(accessToken: string, authenticationType: AuthorizationType) {
+  private saveAccessToken(accessToken: string, authenticationType: AuthorizationType): AuthTokenInfo {
     // Ensure the directory exists
     if (!fs.existsSync(this._cliConfiguration.cacheDir)) {
       fs.mkdirSync(this._cliConfiguration.cacheDir, { recursive: true });

--- a/src/services/general-models/result-response.ts
+++ b/src/services/general-models/result-response.ts
@@ -1,0 +1,3 @@
+export interface ResultResponse {
+  result: string;
+}

--- a/src/services/iTwin-api-client.ts
+++ b/src/services/iTwin-api-client.ts
@@ -43,7 +43,7 @@ export class ITwinPlatformApiClient {
     await this.request(options);
   }
 
-  private getHeadersList(headers: Record<string, string> | undefined, apiVersionHeader: string | undefined) {
+  private getHeadersList(headers: Record<string, string> | undefined, apiVersionHeader: string | undefined): Record<string, string> {
     const headersList: Record<string, string> = {
       // eslint-disable-next-line @typescript-eslint/naming-convention
       Authorization: this._authToken,

--- a/src/services/storage-client/storage-api-client.ts
+++ b/src/services/storage-client/storage-api-client.ts
@@ -139,7 +139,7 @@ export class StorageApiClient {
     });
   }
 
-  public async uploadFile(url: string, file: ArrayBuffer) {
+  public async uploadFile(url: string, file: ArrayBuffer): Promise<Response> {
     return fetch(url, {
       body: file,
       headers: { 'x-ms-blob-type': 'BlockBlob' },

--- a/src/services/synchronizationClient/synchronization-api-client.ts
+++ b/src/services/synchronizationClient/synchronization-api-client.ts
@@ -46,7 +46,7 @@ export class SynchronizationApiClient {
     });
   }
 
-  public async createStorageConnectionRun(connectionId: string) {
+  public async createStorageConnectionRun(connectionId: string): Promise<void> {
     await this._iTwinPlatformApiClient.sendRequestNoResponse({
       apiPath: `synchronization/imodels/storageconnections/${connectionId}/run`,
       method: "POST"


### PR DESCRIPTION
- Added linting rule for enforcing explicit function return types. 
- Renamed BaseCommand.getChangeElementApiClient() -> BaseCommand.getChangedElementsApiClient(). 
- Added ResultResponse interface to src/services/general-models/result-response.ts.